### PR TITLE
Refactor merge_tracks

### DIFF
--- a/modules/tracker.py
+++ b/modules/tracker.py
@@ -148,57 +148,58 @@ class Track:
         """
         
         log.info("Let us merge")
-        new_event_list=[]
-        current_track=self.get_copy()
+        new_event_list = []
+        current_track = self.get_copy()
         log.info(f"Current track: {current_track}")
         # current_track=copy.deepcopy(current_track) #deepcopy not working
 
-        log.info(f"merging {track_to_merge.get_pretty_string()} with {self.get_pretty_string()}")
+        log.info(
+            f"merging {track_to_merge.get_pretty_string()} with {self.get_pretty_string()}"
+        )
 
-        track_to_merge_event_list=track_to_merge.get_copy()
+        track_to_merge_event_list = track_to_merge.get_copy()
 
         if self.get_last_event_time() < track_to_merge.get_first_presence_time():
             # If entire current track is older than entire new track, can just add new track to end of current track
-            for event in track_to_merge.get_track_list():
-                if (self.event_list[0].get_duration() == 0) : 
+            for event in track_to_merge_event_list:
+                if self.event_list[0].get_duration() == 0:
                     self.event_list[0].end(event.get_first_presence_time())
-                self.event_list.insert(0,event)
+                self.event_list.insert(0, event)
 
-            self.last_event_time=track_to_merge.get_last_event_time()
+            self.last_event_time = track_to_merge.get_last_event_time()
 
-        else :
+        else:
 
             # Start the new track with the first event
-            event_to_add=None
-            if track_to_merge[0].get_time_since_last_trigger() < current_track[0].get_time_since_last_trigger():
-                event_to_add=track_to_merge.pop(0)
-            else :
-                event_to_add=current_track.pop(0)
+            event_to_add = None
+            if track_to_merge_event_list[0].get_time_since_last_trigger() < current_track[0].get_time_since_last_trigger():
+                event_to_add = track_to_merge_event_list.pop(0)
+            else:
+                event_to_add = current_track.pop(0)
 
-            if (new_event_list[0].get_duration() == 0) : 
+            if new_event_list and new_event_list[0].get_duration() == 0:
                 new_event_list[0].end(event_to_add.get_first_presence_time())
-
 
             new_event_list.append(event_to_add)
 
             # Add the rest of the events in order of them happening
             while len(current_track) > 0:
 
-                while len(track_to_merge) > 0:
+                while len(track_to_merge_event_list) > 0:
 
-                    if track_to_merge[0].get_time_since_last_trigger() < current_track[0].get_time_since_last_trigger():
-                        new_event_list[0].end(track_to_merge[0].get_first_presence_time())
-                        new_event_list.append(track_to_merge.pop(0))
-                    else :
+                    if track_to_merge_event_list[0].get_time_since_last_trigger() < current_track[0].get_time_since_last_trigger():
+                        new_event_list[0].end(track_to_merge_event_list[0].get_first_presence_time())
+                        new_event_list.append(track_to_merge_event_list.pop(0))
+                    else:
                         break
 
-                new_event_list.append( current_track.pop(0))
+                new_event_list.append(current_track.pop(0))
 
-            while len(track_to_merge) > 0:
-                new_event_list.append( track_to_merge.pop(0))
+            while len(track_to_merge_event_list) > 0:
+                new_event_list.append(track_to_merge_event_list.pop(0))
 
             log.info(f"new merged track: {new_event_list}")
-            self.event_list=new_event_list
+            self.event_list = new_event_list
 
 
     def get_copy(self) :

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -1,0 +1,62 @@
+import builtins
+import logging
+import os
+import time
+
+# Provide dummy implementations required by modules.tracker
+builtins.pyscript_compile = lambda f: f
+builtins.service = lambda f: f
+
+class DummyState:
+    def set(self, *args, **kwargs):
+        pass
+
+builtins.state = DummyState()
+logging.basicConfig(level=logging.INFO)
+builtins.log = logging.getLogger("test")
+
+os.environ["MPLBACKEND"] = "Agg"
+
+# Create minimal config files expected by GraphManager when tracker is imported
+os.makedirs("pyscript", exist_ok=True)
+with open("pyscript/connections.yml", "w") as f:
+    f.write("connections: []")
+
+import importlib.util
+import pathlib
+
+tracker_path = pathlib.Path(__file__).resolve().parents[1] / "modules" / "tracker.py"
+spec = importlib.util.spec_from_file_location("tracker", tracker_path)
+tracker = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(tracker)
+
+
+def test_merge_tracks_no_error_recent_first(tmp_path):
+    t1 = tracker.Track()
+    t1.add_event("a")
+    time.sleep(0.01)
+    t1.add_event("b")
+
+    t2 = tracker.Track()
+    t2.add_event("c")
+    time.sleep(0.01)
+    t2.add_event("d")
+
+    # Should not raise
+    t1.merge_tracks(t2)
+    assert len(t1.get_track_list()) >= 2
+
+
+def test_merge_tracks_no_error_old_first(tmp_path):
+    t2 = tracker.Track()
+    t2.add_event("c")
+    time.sleep(0.01)
+    t2.add_event("d")
+
+    t1 = tracker.Track()
+    t1.add_event("a")
+    time.sleep(0.01)
+    t1.add_event("b")
+
+    t1.merge_tracks(t2)
+    assert len(t1.get_track_list()) >= 2


### PR DESCRIPTION
## Summary
- fix merge_tracks to operate on event list copies
- add regression tests covering both merge paths

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f97f73f48832daa0de00b73214eb3