### PR TITLE
Add scenario YAMLs and tests for tracker

### DIFF
--- a/modules/advanced_tracker.py
+++ b/modules/advanced_tracker.py
@@ -1,0 +1,217 @@
+"""Advanced room-level presence tracking.
+
+This module implements a particle filter based multi-person tracking system.
+It builds on the existing ``tracker`` module but adds probabilistic motion
+tracking for sparse sensor data.
+"""
+
+from __future__ import annotations
+
+import time
+import random
+from collections import defaultdict
+from typing import Dict, List, Optional
+import os
+import yaml
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+import networkx as nx
+
+
+class RoomGraph:
+    """Graph describing connectivity between rooms."""
+
+    def __init__(self, adjacency: Dict[str, List[str]]):
+        self.graph = nx.Graph()
+        for room, neighbours in adjacency.items():
+            for n in neighbours:
+                self.graph.add_edge(room, n)
+
+    def get_neighbors(self, room_id: str) -> List[str]:
+        return list(self.graph.neighbors(room_id))
+
+
+def load_room_graph_from_yaml(path: str) -> RoomGraph:
+    with open(path, "r") as f:
+        data = yaml.safe_load(f)
+    adjacency: Dict[str, List[str]] = defaultdict(list)
+    for pair in data.get("connections", []):
+        for a, b in pair.items():
+            adjacency[a].append(b)
+            adjacency[b].append(a)
+    return RoomGraph(adjacency)
+
+
+class SensorModel:
+    """Models likelihood that a person remains in a room."""
+
+    def __init__(self, cooldown: int = 420, floor_prob: float = 0.05):
+        self.cooldown = cooldown
+        self.floor_prob = floor_prob
+        self.last_fire: Dict[str, float] = defaultdict(lambda: 0.0)
+
+    def record_trigger(self, room_id: str, timestamp: Optional[float] = None) -> None:
+        self.last_fire[room_id] = time.time() if timestamp is None else timestamp
+
+    def likelihood_still_present(self, room_id: str, current_time: Optional[float] = None) -> float:
+        now = time.time() if current_time is None else current_time
+        dt = now - self.last_fire.get(room_id, 0.0)
+        if dt <= 0:
+            return 1.0
+        if dt >= self.cooldown:
+            return self.floor_prob
+        return 1.0 - (dt / self.cooldown) * (1.0 - self.floor_prob)
+
+
+class Particle:
+    def __init__(self, room: str, weight: float = 1.0):
+        self.room = room
+        self.weight = weight
+
+    def move(self, room_graph: RoomGraph) -> None:
+        neighbors = room_graph.get_neighbors(self.room)
+        if neighbors:
+            self.room = random.choice(neighbors)
+
+    def copy(self) -> "Particle":
+        return Particle(self.room, self.weight)
+
+
+class PersonTracker:
+    """Particle filter tracker for a single person."""
+
+    def __init__(self, room_graph: RoomGraph, sensor_model: SensorModel, num_particles: int = 100):
+        self.room_graph = room_graph
+        self.sensor_model = sensor_model
+        self.particles: List[Particle] = []
+        self.last_sensor_room: Optional[str] = None
+        self.last_sensor_time: float = 0.0
+        self._init_particles(num_particles)
+
+    def _init_particles(self, n: int) -> None:
+        rooms = list(self.room_graph.graph.nodes)
+        for _ in range(n):
+            room = random.choice(rooms)
+            self.particles.append(Particle(room))
+
+    def update(self, current_time: float, sensor_room: Optional[str] = None) -> None:
+        if sensor_room is not None:
+            self.last_sensor_room = sensor_room
+            self.last_sensor_time = current_time
+            self.sensor_model.record_trigger(sensor_room, current_time)
+
+        for p in self.particles:
+            p.move(self.room_graph)
+            weight = self.sensor_model.likelihood_still_present(p.room, current_time)
+            if self.last_sensor_room and p.room == self.last_sensor_room:
+                weight *= 1.5
+            p.weight = weight
+
+        # Resample
+        total = sum(p.weight for p in self.particles)
+        if total == 0:
+            total = 1.0
+        cumulative = []
+        acc = 0.0
+        for p in self.particles:
+            acc += p.weight / total
+            cumulative.append(acc)
+        new_particles = []
+        for _ in self.particles:
+            r = random.random()
+            for i, c in enumerate(cumulative):
+                if r <= c:
+                    new_particles.append(Particle(self.particles[i].room))
+                    break
+        self.particles = new_particles
+
+    def estimate(self) -> str:
+        counts: Dict[str, int] = defaultdict(int)
+        for p in self.particles:
+            counts[p.room] += 1
+        if not counts:
+            return "unknown"
+        return max(counts.items(), key=lambda x: x[1])[0]
+
+    def distribution(self) -> Dict[str, float]:
+        counts: Dict[str, int] = defaultdict(int)
+        for p in self.particles:
+            counts[p.room] += 1
+        total = len(self.particles)
+        if total == 0:
+            return {}
+        return {room: count / total for room, count in counts.items()}
+
+
+class MultiPersonTracker:
+    def __init__(self, room_graph: RoomGraph, sensor_model: SensorModel, *, debug: bool = False, debug_dir: str = "debug"):
+        self.room_graph = room_graph
+        self.sensor_model = sensor_model
+        self.trackers: Dict[str, PersonTracker] = {}
+        self.debug = debug
+        self.debug_dir = debug_dir
+        self._debug_counter = 0
+        if self.debug:
+            os.makedirs(self.debug_dir, exist_ok=True)
+            self._layout = nx.kamada_kawai_layout(self.room_graph.graph)
+
+    def process_event(self, person_id: str, room_id: str, timestamp: Optional[float] = None) -> None:
+        now = time.time() if timestamp is None else timestamp
+        tracker = self.trackers.get(person_id)
+        if tracker is None:
+            tracker = PersonTracker(self.room_graph, self.sensor_model)
+            self.trackers[person_id] = tracker
+        tracker.update(now, sensor_room=room_id)
+        if self.debug:
+            self._visualize(now)
+
+    def step(self) -> None:
+        now = time.time()
+        for tracker in self.trackers.values():
+            tracker.update(now)
+        if self.debug:
+            self._visualize(now)
+
+    def estimate_locations(self) -> Dict[str, str]:
+        return {pid: tracker.estimate() for pid, tracker in self.trackers.items()}
+
+    def _visualize(self, current_time: float) -> None:
+        plt.clf()
+        fig, ax = plt.subplots(figsize=(6, 4))
+        nx.draw_networkx(self.room_graph.graph, pos=self._layout, ax=ax, node_color='lightgray', edgecolors='black')
+
+        colors = {
+            0: (1, 0, 0),
+            1: (0, 1, 0),
+            2: (0, 0, 1),
+        }
+        for idx, (pid, tracker) in enumerate(self.trackers.items()):
+            dist = tracker.distribution()
+            node_colors = []
+            for node in self.room_graph.graph.nodes:
+                intensity = dist.get(node, 0.0)
+                base = colors.get(idx % 3, (0, 0, 0))
+                node_colors.append(tuple(intensity * c for c in base))
+            nx.draw_networkx_nodes(
+                self.room_graph.graph,
+                pos=self._layout,
+                nodelist=list(self.room_graph.graph.nodes),
+                node_color=node_colors,
+                node_size=400,
+                ax=ax,
+            )
+        ax.set_title(f"t={current_time:.1f}")
+        ax.axis('off')
+        filename = os.path.join(self.debug_dir, f"frame_{self._debug_counter:06d}.png")
+        plt.savefig(filename)
+        plt.close(fig)
+        self._debug_counter += 1
+
+
+def init_from_yaml(connections_path: str, *, debug: bool = False, debug_dir: str = "debug") -> MultiPersonTracker:
+    graph = load_room_graph_from_yaml(connections_path)
+    sensor_model = SensorModel()
+    return MultiPersonTracker(graph, sensor_model, debug=debug, debug_dir=debug_dir)
+

--- a/tests/scenarios/simple_connections.yml
+++ b/tests/scenarios/simple_connections.yml
@@ -1,0 +1,3 @@
+connections:
+  - bedroom: hallway
+  - hallway: kitchen

--- a/tests/scenarios/simple_walk.yml
+++ b/tests/scenarios/simple_walk.yml
@@ -1,0 +1,10 @@
+connections: tests/scenarios/simple_connections.yml
+persons:
+  - id: p1
+    events:
+      - time: 0
+        room: bedroom
+      - time: 600
+        room: hallway
+expected_final:
+  p1: hallway

--- a/tests/scenarios/two_persons.yml
+++ b/tests/scenarios/two_persons.yml
@@ -1,0 +1,13 @@
+connections: tests/scenarios/simple_connections.yml
+persons:
+  - id: alice
+    events:
+      - time: 0
+        room: bedroom
+  - id: bob
+    events:
+      - time: 30
+        room: kitchen
+expected_final:
+  alice: bedroom
+  bob: hallway

--- a/tests/test_advanced_tracker.py
+++ b/tests/test_advanced_tracker.py
@@ -1,0 +1,89 @@
+import os
+import unittest
+import tempfile
+
+import yaml
+
+from modules.advanced_tracker import (
+    load_room_graph_from_yaml,
+    SensorModel,
+    PersonTracker,
+    MultiPersonTracker,
+)
+
+
+class TestAdvancedTracker(unittest.TestCase):
+    def test_load_graph(self):
+        graph = load_room_graph_from_yaml('connections.yml')
+        self.assertIn('bedroom', graph.get_neighbors('bathroom'))
+        self.assertIn('bathroom', graph.get_neighbors('bedroom'))
+
+    def test_person_distribution(self):
+        graph = load_room_graph_from_yaml('connections.yml')
+        sensor_model = SensorModel()
+        tracker = PersonTracker(graph, sensor_model, num_particles=10)
+        now = 0.0
+        tracker.update(now, sensor_room='bedroom')
+        dist = tracker.distribution()
+        self.assertAlmostEqual(sum(dist.values()), 1.0, places=5)
+
+    def test_debug_visualization(self):
+        graph = load_room_graph_from_yaml('connections.yml')
+        sensor_model = SensorModel()
+        with tempfile.TemporaryDirectory() as tmp:
+            multi = MultiPersonTracker(graph, sensor_model, debug=True, debug_dir=tmp)
+            multi.process_event('p1', 'bedroom', timestamp=0.0)
+            multi.step()
+            files = sorted(os.listdir(tmp))
+        self.assertTrue(any(f.startswith('frame_') and f.endswith('.png') for f in files))
+
+    def _run_yaml_scenario(self, path: str):
+        with open(path, 'r') as f:
+            scenario = yaml.safe_load(f)
+
+        graph = load_room_graph_from_yaml(scenario['connections'])
+        sensor_model = SensorModel()
+        multi = MultiPersonTracker(graph, sensor_model)
+
+        # Build mapping of time -> list of (pid, room)
+        time_events = {}
+        for person in scenario.get('persons', []):
+            pid = person['id']
+            for ev in person.get('events', []):
+                t = ev['time']
+                time_events.setdefault(t, []).append((pid, ev['room']))
+
+        random_seed = scenario.get('seed', 0)
+        import random
+        random.seed(random_seed)
+
+        max_t = max(time_events) if time_events else 0
+
+        current = 0
+        while current <= max_t:
+            events = time_events.get(current, [])
+            updated = set()
+            for pid, room in events:
+                multi.process_event(pid, room, timestamp=current)
+                updated.add(pid)
+
+            for pid, tracker in multi.trackers.items():
+                if pid not in updated:
+                    tracker.update(current)
+
+            current += 1
+
+        return multi.estimate_locations(), scenario.get('expected_final', {})
+
+    def test_yaml_scenarios(self):
+        scenario_dir = os.path.join('tests', 'scenarios')
+        for fname in os.listdir(scenario_dir):
+            if not fname.endswith('.yml') or 'connections' in fname:
+                continue
+            result, expected = self._run_yaml_scenario(os.path.join(scenario_dir, fname))
+            for pid, room in expected.items():
+                self.assertEqual(result.get(pid), room)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- create simple connection graph fixture
- define YAML scenarios for single and multi-person cases
- load scenarios in unit tests to drive the particle tracker

## Testing
- `python -m py_compile modules/advanced_tracker.py tests/test_advanced_tracker.py`
- `python -m unittest -v tests.test_advanced_tracker`


------
https://chatgpt.com/codex/tasks/task_e_684f9db6afe8832d9ddb92981067d837