### PR TITLE
Add calibrated thermometer and humidity sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ The repository relies on several YAML files:
   `max_light_distance`—the allowed patch of sunlight on the floor (default is
   roughly one foot). Windows may also define a `device` ID for the blind
   associated with that opening.
+- [`sensor_config.yml`](sensor_config.yml) keeps calibration offsets for
+  thermometers and humidity sensors.
 
 These files are loaded at startup and are referenced throughout the code.
 

--- a/sensor_config.yml
+++ b/sensor_config.yml
@@ -1,0 +1,2 @@
+thermometers: {}
+humidity_sensors: {}

--- a/tests/test_sensor_calibration.py
+++ b/tests/test_sensor_calibration.py
@@ -1,0 +1,25 @@
+import yaml
+from .test_caching import load_area_tree
+
+area_tree = load_area_tree()
+ThermometerDriver = area_tree.ThermometerDriver
+HumiditySensorDriver = area_tree.HumiditySensorDriver
+
+
+def test_thermometer_calibration(tmp_path):
+    cfg = tmp_path / "cal.yml"
+    driver = ThermometerDriver("temp1", config_path=str(cfg))
+    driver.calibrate(2.5)
+    with open(cfg) as f:
+        data = yaml.safe_load(f)
+    assert data["thermometers"]["temp1"] == 2.5
+
+
+def test_humidity_calibration(tmp_path):
+    cfg = tmp_path / "cal.yml"
+    driver = HumiditySensorDriver("hum1", config_path=str(cfg))
+    driver.calibrate(-1.0)
+    with open(cfg) as f:
+        data = yaml.safe_load(f)
+    assert data["humidity_sensors"]["hum1"] == -1.0
+


### PR DESCRIPTION
## Summary
- add `ThermometerDriver` and `HumiditySensorDriver`
- support calibration via new `calibrate_sensor` service
- create `sensor_config.yml` file for storing calibration offsets
- update README with new config file
- test calibration logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fa9cca4e8832d8d0c0e471840da12