### PR TITLE
Add television driver and events

### DIFF
--- a/devices.yml
+++ b/devices.yml
@@ -149,3 +149,8 @@ blind_bedroom_window:
 
 # Outputs
 
+living_room_tv:
+  type: tv
+  filters:
+    - tv
+

--- a/layout.yml
+++ b/layout.yml
@@ -102,7 +102,7 @@ living_room_middle:
       - "presence_sensor_living_room_middle"
 
   outputs:
-    -
+    - living_room_tv
 
 living_room_couch:
   sub_areas:

--- a/rules.yml
+++ b/rules.yml
@@ -99,3 +99,19 @@ living_room_zones_on:
 #     - lesser_siblings: []
 #   state:
 #     status: 0
+
+tv_power_on:
+  trigger_prefix: "living_room_tv"
+  required_tags: ["on"]
+  scope_functions:
+    - get_area_local_scope: []
+  state:
+    status: 1
+
+tv_power_off:
+  trigger_prefix: "living_room_tv"
+  required_tags: ["off"]
+  scope_functions:
+    - get_area_local_scope: []
+  state:
+    status: 0


### PR DESCRIPTION
## Summary
- add `TelevisionDriver` capable of triggering events on state change
- support creating TV devices when building the area tree
- add a living room TV to the layout and device catalog
- add example rules reacting to TV power events

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684faa70b274832d9fad6369a735e8fd