### PR TITLE
Add PlugDriver and fan wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ the full implementations.
 - **`BlindDriver`** – Handles smart blinds that accept either a percentage
   closed or a physical height. Heights are converted to percentages using the
   configured blind height.
+- **`PlugDriver`** – Controls smart plugs and can report optional `power` and
+  `current` readings.
+- **`FanDriver`** – Wraps a `PlugDriver` so fans can be treated like any other
+  device while using a plug under the hood.
 
 ## Event and Rule Workflow
 

--- a/devices.yml
+++ b/devices.yml
@@ -149,3 +149,14 @@ blind_bedroom_window:
 
 # Outputs
 
+smart_plug_example:
+  type: plug
+  filters:
+    - plug
+
+living_room_fan:
+  type: fan
+  filters:
+    - fan
+    - plug
+

--- a/tests/test_plug_driver.py
+++ b/tests/test_plug_driver.py
@@ -1,0 +1,38 @@
+from .test_caching import load_area_tree
+
+
+def test_plug_driver_basic():
+    mod = load_area_tree()
+
+    class DummySwitch:
+        def __init__(self):
+            self.last = None
+        def turn_on(self, entity_id=None, **kwargs):
+            self.last = ("on", entity_id)
+        def turn_off(self, entity_id=None, **kwargs):
+            self.last = ("off", entity_id)
+
+    class DummyState:
+        def __init__(self):
+            self.data = {}
+        def get(self, key):
+            return self.data.get(key)
+
+    mod.switch = DummySwitch()
+    mod.state = DummyState()
+    mod.state.data["switch.test_plug"] = "off"
+    mod.state.data["sensor.test_plug_power"] = 15
+    mod.state.data["sensor.test_plug_current"] = 0.5
+
+    plug = mod.PlugDriver(
+        "test_plug",
+        power_sensor="sensor.test_plug_power",
+        current_sensor="sensor.test_plug_current",
+    )
+
+    state = plug.get_state()
+    assert state == {"status": 0, "power": 15, "current": 0.5}
+
+    plug.set_state({"status": 1})
+    assert mod.switch.last == ("on", "switch.test_plug")
+    assert plug.last_state["status"] == 1


### PR DESCRIPTION
## Summary
- add `PlugDriver` for smart plugs with optional power and current sensors
- wrap `PlugDriver` inside new `FanDriver`
- auto-create plug and fan devices when building the area tree
- document plug and fan drivers in the README
- show example entries in `devices.yml`
- test plug driver behavior

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fb204df24832d82f4b0e4d6805088