### PR TITLE
Add SpeakerDriver and sample speaker support

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ the full implementations.
 - **`BlindDriver`** – Handles smart blinds that accept either a percentage
   closed or a physical height. Heights are converted to percentages using the
   configured blind height.
+- **`SpeakerDriver`** – Controls media speakers like Google Home. Tracks volume
+  and what is currently playing, and allows adjusting volume via `set_state()`.
 
 ## Event and Rule Workflow
 

--- a/area_tree.py
+++ b/area_tree.py
@@ -1339,6 +1339,14 @@ class AreaTree:
                                 new_device.set_area(area)
 
                                 area_tree[output] = new_device
+                            elif "speaker" in output or "google_home" in output:
+                                new_speaker = SpeakerDriver(output)
+                                new_device = Device(new_speaker)
+
+                                area.add_device(new_device)
+                                new_device.set_area(area)
+
+                                area_tree[output] = new_device
 
                 # Add outputs as children
                 if "inputs" in area_data:
@@ -1986,6 +1994,47 @@ class BlindDriver:
             self.last_state = {"closed_percent": percent}
             if self.height:
                 self.last_state["height"] = self.height * (100 - percent) / 100
+        return self.last_state
+
+
+class SpeakerDriver:
+    """Driver for smart speakers such as Google Home."""
+
+    def __init__(self, name):
+        self.name = name
+        self.last_state = {"volume": None, "playing": None}
+
+    def get_valid_state_keys(self):
+        return ["volume"]
+
+    def filter_state(self, state):
+        valid = self.get_valid_state_keys()
+        return {k: v for k, v in state.items() if k in valid}
+
+    def get_state(self):
+        volume = None
+        playing = None
+        try:
+            volume = state.get(f"media_player.{self.name}.volume_level")
+        except Exception:
+            pass
+        try:
+            status = state.get(f"media_player.{self.name}.state")
+            if status == "playing":
+                playing = state.get(f"media_player.{self.name}.media_title")
+        except Exception:
+            pass
+        self.last_state = {"volume": volume, "playing": playing}
+        return self.last_state
+
+    def set_state(self, state):
+        state = self.filter_state(state)
+        if "volume" in state and state["volume"] is not None:
+            try:
+                media_player.volume_set(entity_id=f"media_player.{self.name}", volume_level=state["volume"])
+            except Exception as e:
+                log.warning(f"Failed to set volume for {self.name}: {e}")
+        self.last_state.update(state)
         return self.last_state
 
 

--- a/devices.yml
+++ b/devices.yml
@@ -149,3 +149,9 @@ blind_bedroom_window:
 
 # Outputs
 
+google_home_speaker:
+  type: speaker
+  filters:
+    - speaker
+    - google_home
+

--- a/layout.yml
+++ b/layout.yml
@@ -45,7 +45,7 @@ living_room:
       - "presence_sensor_living_room"
 
   outputs:
-    -
+    - google_home_speaker
 
 living_room_chairs:
   direct_sub_areas:

--- a/tests/test_speaker_driver.py
+++ b/tests/test_speaker_driver.py
@@ -1,0 +1,14 @@
+import types
+from tests.test_caching import load_area_tree
+
+def test_speaker_driver_volume():
+    area_tree = load_area_tree()
+    calls = []
+    area_tree.media_player = types.SimpleNamespace(volume_set=lambda **kw: calls.append(kw))
+    SpeakerDriver = area_tree.SpeakerDriver
+    driver = SpeakerDriver('living_room')
+    # ensure filter_state removes invalid keys
+    filtered = driver.filter_state({'volume': 0.5, 'invalid': 1})
+    assert filtered == {'volume': 0.5}
+    driver.set_state({'volume': 0.7})
+    assert calls and calls[0]['volume_level'] == 0.7


### PR DESCRIPTION
## Summary
- add `SpeakerDriver` class for Google Home/media speakers
- create speaker devices in the area tree when outputs contain `speaker`
- document the new driver
- add `google_home_speaker` example to configuration
- include tests for speaker driver filtering and volume control

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fc2b29464832d8592fe3c7801d776