### PR TITLE
Add PlugDriver and fan wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ the full implementations.
 - **`BlindDriver`** – Handles smart blinds that accept either a percentage
   closed or a physical height. Heights are converted to percentages using the
   configured blind height.
+- **`PlugDriver`** – Controls smart plugs and can report optional `power` and
+  `current` readings.
+- **`FanDriver`** – Wraps a `PlugDriver` so fans can be treated like any other
+  device while using a plug under the hood.
+- **`SpeakerDriver`** – Controls media speakers like Google Home. Tracks volume
+  and what is currently playing, and allows adjusting volume via `set_state()`.
 
 ## Event and Rule Workflow
 

--- a/devices.yml
+++ b/devices.yml
@@ -149,3 +149,19 @@ blind_bedroom_window:
 
 # Outputs
 
+smart_plug_example:
+  type: plug
+  filters:
+    - plug
+
+living_room_fan:
+  type: fan
+  filters:
+    - fan
+    - plug
+google_home_speaker:
+  type: speaker
+  filters:
+    - speaker
+    - google_home
+

--- a/layout.yml
+++ b/layout.yml
@@ -45,7 +45,7 @@ living_room:
       - "presence_sensor_living_room"
 
   outputs:
-    -
+    - google_home_speaker
 
 living_room_chairs:
   direct_sub_areas:

--- a/modules/tracker.py
+++ b/modules/tracker.py
@@ -3,6 +3,7 @@ import networkx as nx
 import matplotlib.pyplot as plt
 import time
 import copy
+import os
 
 
 
@@ -441,9 +442,10 @@ class GraphManager:
             "edgecolors": "black",
             "linewidths": 2,
             "width": 1,
-            "with_labels":True,
+            "with_labels": False,
         }
         nx.draw_networkx(graph, pos, **options)
+        nx.draw_networkx_labels(graph, pos)
 
         plt.axis("off")
         log.info(f"Saving graph to {filename}")
@@ -469,7 +471,13 @@ example_track = [
 def plot_graph():
     log.info(f"STARTING")
     graph_manager = GraphManager("./pyscript/connections.yml")
-    graph_manager.visualize_graph()
+    output = "pyscript/graph2.png"
+    graph_manager.visualize_graph(output_file=output)
+    try:
+        size = os.path.getsize(output)
+        log.info(f"Graph saved to {output} ({size} bytes)")
+    except OSError as exc:
+        log.error(f"Could not verify graph output: {exc}")
 
 
 plot_graph()

--- a/tests/test_plug_driver.py
+++ b/tests/test_plug_driver.py
@@ -1,0 +1,38 @@
+from .test_caching import load_area_tree
+
+
+def test_plug_driver_basic():
+    mod = load_area_tree()
+
+    class DummySwitch:
+        def __init__(self):
+            self.last = None
+        def turn_on(self, entity_id=None, **kwargs):
+            self.last = ("on", entity_id)
+        def turn_off(self, entity_id=None, **kwargs):
+            self.last = ("off", entity_id)
+
+    class DummyState:
+        def __init__(self):
+            self.data = {}
+        def get(self, key):
+            return self.data.get(key)
+
+    mod.switch = DummySwitch()
+    mod.state = DummyState()
+    mod.state.data["switch.test_plug"] = "off"
+    mod.state.data["sensor.test_plug_power"] = 15
+    mod.state.data["sensor.test_plug_current"] = 0.5
+
+    plug = mod.PlugDriver(
+        "test_plug",
+        power_sensor="sensor.test_plug_power",
+        current_sensor="sensor.test_plug_current",
+    )
+
+    state = plug.get_state()
+    assert state == {"status": 0, "power": 15, "current": 0.5}
+
+    plug.set_state({"status": 1})
+    assert mod.switch.last == ("on", "switch.test_plug")
+    assert plug.last_state["status"] == 1

--- a/tests/test_speaker_driver.py
+++ b/tests/test_speaker_driver.py
@@ -1,0 +1,14 @@
+import types
+from tests.test_caching import load_area_tree
+
+def test_speaker_driver_volume():
+    area_tree = load_area_tree()
+    calls = []
+    area_tree.media_player = types.SimpleNamespace(volume_set=lambda **kw: calls.append(kw))
+    SpeakerDriver = area_tree.SpeakerDriver
+    driver = SpeakerDriver('living_room')
+    # ensure filter_state removes invalid keys
+    filtered = driver.filter_state({'volume': 0.5, 'invalid': 1})
+    assert filtered == {'volume': 0.5}
+    driver.set_state({'volume': 0.7})
+    assert calls and calls[0]['volume_level'] == 0.7


### PR DESCRIPTION
## Summary
- add `PlugDriver` with optional power and current readings
- wrap `PlugDriver` inside `FanDriver`
- integrate new `SpeakerDriver` from main
- auto-create plug, fan and speaker devices when building the area tree
- update example device entries and README
- include basic tests for speaker and plug drivers

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684fb204df24832d82f4b0e4d6805088