### PR TITLE
Add new tests for device and tracker logic

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,97 @@
+import types
+import sys
+import importlib.util
+import copy
+import builtins
+
+
+def _stub_decorator(*dargs, **dkwargs):
+    if len(dargs) == 1 and callable(dargs[0]) and not dkwargs:
+        return dargs[0]
+    def wrapper(func):
+        return func
+    return wrapper
+
+
+class DummyLog:
+    def info(self, *a, **k):
+        pass
+    def warning(self, *a, **k):
+        pass
+    def fatal(self, *a, **k):
+        pass
+
+
+def load_area_tree():
+    pyscript_mod = types.ModuleType('pyscript')
+    pyscript_mod.k_to_rgb = types.ModuleType('pyscript.k_to_rgb')
+    pyscript_mod.k_to_rgb.convert_K_to_RGB = lambda x: x
+    pyscript_mod.service = _stub_decorator
+    pyscript_mod.event_trigger = _stub_decorator
+    pyscript_mod.pyscript_compile = _stub_decorator
+    sys.modules['pyscript'] = pyscript_mod
+    sys.modules['pyscript.k_to_rgb'] = pyscript_mod.k_to_rgb
+
+    sys.modules['homeassistant'] = types.ModuleType('homeassistant')
+    sys.modules['homeassistant.const'] = types.ModuleType('homeassistant.const')
+    sys.modules['homeassistant.const'].EVENT_CALL_SERVICE = 'call_service'
+
+    tracker_mod = types.ModuleType('tracker')
+    tracker_mod.TrackManager = object
+    tracker_mod.Track = object
+    tracker_mod.Event = object
+    sys.modules['tracker'] = tracker_mod
+
+    with open('area_tree.py') as f:
+        lines = [line for line in f.readlines()
+                 if not (line.strip() in {"init()", "run_tests()"} and not line.startswith(" "))]
+    code = ''.join(lines)
+
+    spec = importlib.util.spec_from_loader('area_tree', loader=None)
+    mod = importlib.util.module_from_spec(spec)
+    mod.log = DummyLog()
+    mod.service = _stub_decorator
+    mod.event_trigger = _stub_decorator
+    mod.pyscript_compile = _stub_decorator
+    sys.modules['area_tree'] = mod
+    exec(code, mod.__dict__)
+    return mod
+
+
+def load_tracker():
+    pyscript_mod = types.ModuleType('pyscript')
+    pyscript_mod.service = _stub_decorator
+    pyscript_mod.event_trigger = _stub_decorator
+    pyscript_mod.pyscript_compile = _stub_decorator
+    sys.modules['pyscript'] = pyscript_mod
+
+    class DummyState:
+        def set(self, *a, **k):
+            pass
+        def get(self, *a, **k):
+            return None
+    dummy_state = DummyState()
+
+    sys.modules['state'] = dummy_state
+    sys.modules['light'] = types.ModuleType('light')
+    sys.modules['light'].turn_on = lambda *a, **k: None
+    sys.modules['light'].turn_off = lambda *a, **k: None
+
+    with open('modules/tracker.py') as f:
+        lines = []
+        for line in f.readlines():
+            if line.strip() in {'plot_graph()'} and not line.startswith(' '):
+                continue
+            line = line.replace('./pyscript/connections.yml', 'tests/scenarios/simple_connections.yml')
+            lines.append(line)
+    code = ''.join(lines)
+    spec = importlib.util.spec_from_loader('modules.tracker', loader=None)
+    mod = importlib.util.module_from_spec(spec)
+    mod.log = DummyLog()
+    mod.state = dummy_state
+    mod.light = sys.modules['light']
+    mod.pyscript_compile = _stub_decorator
+    mod.service = _stub_decorator
+    sys.modules['modules.tracker'] = mod
+    exec(code, mod.__dict__)
+    return mod

--- a/tests/test_device_features.py
+++ b/tests/test_device_features.py
@@ -1,0 +1,52 @@
+import copy
+import time
+from .conftest import load_area_tree
+
+
+def test_brightness_caching():
+    area_tree = load_area_tree()
+    Device = area_tree.Device
+
+    class DummyDriver:
+        def __init__(self, name='dummy'):
+            self.name = name
+            self.state = {}
+        def get_state(self):
+            return copy.deepcopy(self.state)
+        def set_state(self, state):
+            self.state.update(state)
+            return copy.deepcopy(self.state)
+        def filter_state(self, state):
+            return state
+
+    d = Device(DummyDriver('light1'))
+    d.set_state({'brightness': 100})
+    assert d.get_state()['brightness'] == 100
+    d.set_state({'brightness': 200})
+    assert d.get_state()['brightness'] == 200
+
+
+def test_button_trigger_event_creation():
+    area_tree = load_area_tree()
+    Device = area_tree.Device
+
+    events = []
+    class DummyEventManager:
+        def create_event(self, event):
+            events.append(event)
+
+    area_tree.event_manager = DummyEventManager()
+
+    class DummyDriver:
+        def __init__(self, name='dummy'):
+            self.name = name
+        def get_state(self):
+            return {'name': self.name}
+        def filter_state(self, state):
+            return state
+
+    Area = area_tree.Area
+    d = Device(DummyDriver('button1'))
+    d.set_area(Area('area'))
+    d.input_trigger(['press'])
+    assert events == [{'device_name': 'button1', 'tags': ['press']}]

--- a/tests/test_motion_state.py
+++ b/tests/test_motion_state.py
@@ -1,0 +1,37 @@
+import types
+import time
+from .conftest import load_area_tree
+
+
+def test_time_based_state_morning(monkeypatch):
+    area_tree = load_area_tree()
+    get_time_based_state = area_tree.get_time_based_state
+    Area = area_tree.Area
+
+    class DummyDevice:
+        def __init__(self, name):
+            self.name = name
+            self.state = {'status': 0}
+        def set_state(self, s):
+            self.state.update(s)
+        def get_state(self):
+            return dict(self.state, name=self.name)
+        def get_last_state(self):
+            return self.get_state()
+        def get_pretty_string(self, *a, **k):
+            return self.name
+
+    area = Area('room')
+    dev = DummyDevice('light')
+    area.add_device(dev)
+
+    def fake_localtime():
+        class T(tuple):
+            tm_hour = 9
+        return T()
+    monkeypatch.setattr(time, 'localtime', fake_localtime)
+
+    state = get_time_based_state(dev, [area])
+    assert state['status'] == 1
+    assert state['brightness'] == 255
+    assert state['color_temp'] == 350

--- a/tests/test_track_manager.py
+++ b/tests/test_track_manager.py
@@ -1,0 +1,22 @@
+from .conftest import load_tracker
+
+
+def test_track_manager_basic_merge():
+    tracker = load_tracker()
+    TrackManager = tracker.TrackManager
+    GraphManager = tracker.GraphManager
+
+    # disable visualization to avoid file writes
+    tracker.GraphManager.visualize_graph = lambda *a, **k: None
+
+    tm = TrackManager()
+    tm.graph_manager = GraphManager('tests/scenarios/simple_connections.yml')
+
+    tm.add_event('bedroom')
+    tm.add_event('hallway')
+    tm.add_event('kitchen')
+
+    tracks = tm.get_tracks()
+    assert len(tracks) == 1
+    assert len(tracks[0]) == 3
+    assert [e.get_area() for e in tracks[0]] == ['kitchen', 'hallway', 'bedroom']


### PR DESCRIPTION
## Summary
- add helper fixtures for loading modules with stubs
- test brightness caching and button triggers
- test time-based state logic deterministically
- verify TrackManager merges events correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685041c74d14832d9acc1556d1470539