### PR TITLE
Use task.sleep async approach

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,14 @@ def load_area_tree():
     pyscript_mod.service = _stub_decorator
     pyscript_mod.event_trigger = _stub_decorator
     pyscript_mod.pyscript_compile = _stub_decorator
+    class DummyTask:
+        async def sleep(self, *_args, **_kwargs):
+            pass
+
+        def create_task(self, coro):
+            return coro
+
+    pyscript_mod.task = DummyTask()
     sys.modules['pyscript'] = pyscript_mod
     sys.modules['pyscript.k_to_rgb'] = pyscript_mod.k_to_rgb
 
@@ -63,6 +71,14 @@ def load_tracker():
     pyscript_mod.service = _stub_decorator
     pyscript_mod.event_trigger = _stub_decorator
     pyscript_mod.pyscript_compile = _stub_decorator
+    class DummyTask:
+        async def sleep(self, *_args, **_kwargs):
+            pass
+
+        def create_task(self, coro):
+            return coro
+
+    pyscript_mod.task = DummyTask()
     sys.modules['pyscript'] = pyscript_mod
 
     class DummyState:

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -19,6 +19,14 @@ def load_area_tree():
     pyscript_mod.service = stub_decorator
     pyscript_mod.event_trigger = stub_decorator
     pyscript_mod.pyscript_compile = stub_decorator
+    class DummyTask:
+        async def sleep(self, *_args, **_kwargs):
+            pass
+
+        def create_task(self, coro):
+            return coro
+
+    pyscript_mod.task = DummyTask()
     sys.modules['pyscript'] = pyscript_mod
     sys.modules['pyscript.k_to_rgb'] = pyscript_mod.k_to_rgb
 


### PR DESCRIPTION
## Summary
- use `task.sleep` instead of `time.sleep`
- convert service and test helpers to `async`
- schedule `run_tests` via `task.create_task`
- stub `task` in tests

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685051adcda8832d9a96d3e8f27788b0