### PR TITLE
Integrate advanced tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,10 @@ the full implementations.
 - **`EventManager`** – Reads `rules.yml`, watches for events, and executes rules
   using `execute_rule()`. It handles scope resolution, state combination and
   running any additional functions defined by a rule.
-- **`TrackManager`, `Track` and `Event`** – Found in
-  [`modules/tracker.py`](modules/tracker.py). These classes maintain a sequence
-  of presence events and can merge tracks or visualize area transitions.
+- **`MultiPersonTracker`**, **`PersonTracker`**, and related helpers – Implemented
+  in [`modules/advanced_tracker.py`](modules/advanced_tracker.py). This tracker
+  uses a particle filter to follow people through connected areas and can
+  visualize its belief state.
 - **`SunTracker`** – See [`modules/sun_tracker.py`](modules/sun_tracker.py) for
   calculating the sun's position and determining whether an area faces the sun.
   The class also provides `recommended_blind_closure()` to compute how far to
@@ -113,7 +114,12 @@ See the [`execute_rule`](area_tree.py) method for the full logic.
 
 ## Presence Tracking
 
-[`modules/tracker.py`](modules/tracker.py) maintains a history of movement between areas using a connection graph from [`connections.yml`](connections.yml). The `TrackManager` collects events, merges tracks, and can visualize the graph of recent locations. Functions such as `update_tracker` in [`area_tree.py`](area_tree.py) feed sensor events into the tracker.
+
+[`modules/advanced_tracker.py`](modules/advanced_tracker.py) implements a
+particle-filter based tracker. It follows people through the area graph defined
+in [`connections.yml`](connections.yml) and can output visualization frames. The
+`update_tracker` function in [`area_tree.py`](area_tree.py) feeds motion sensor
+events into the tracker and logs each generated frame.
 
 When more than one track is close enough to merge with a new event, the manager
 looks at each candidate's last step. It compares the expected next hop along the

--- a/area_tree.py
+++ b/area_tree.py
@@ -5,8 +5,9 @@ import time
 from pyscript.k_to_rgb import convert_K_to_RGB
 from acrylic import Color
 from homeassistant.const import EVENT_CALL_SERVICE
-from tracker import TrackManager, Track, Event
+from modules.advanced_tracker import init_from_yaml, MultiPersonTracker
 from modules.adaptive_learning import get_learner
+import os
 import unittest
 
 
@@ -62,7 +63,9 @@ def init():
     global_triggers = []
     area_tree = AreaTree("./pyscript/layout.yml")
     event_manager = EventManager("./pyscript/rules.yml", area_tree)
-    tracker_manager = TrackManager()
+    tracker_manager = init_from_yaml(
+        "./pyscript/connections.yml", debug=True, debug_dir="pyscript/tracker_debug"
+    )
 
 
 def get_global_triggers():
@@ -914,17 +917,18 @@ def load_yaml(path):
 
 ### Tracker interface
 def update_tracker(device, *args):
-    tracker_manager=get_tracker_manager()
-
-    tracker_manager.add_event(device.get_area().name)
+    tracker_manager = get_tracker_manager()
+    room = device.get_area().name
+    tracker_manager.process_event("p1", room)
+    image_path = os.path.join(
+        tracker_manager.debug_dir,
+        f"frame_{tracker_manager._debug_counter-1:06d}.png",
+    )
+    log.info(f"update_tracker: image saved to {image_path}")
     try:
-        get_learner().record_presence(device.get_area().name)
+        get_learner().record_presence(room)
     except Exception as e:
         log.warning(f"AdaptiveLearner failed to record presence: {e}")
-
-    log.info(f"update_tracker: Current tracks")
-    for track in tracker_manager.tracks:
-        log.info(f"update_tracker: {track.get_pretty_string()}")
 
     return True
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,19 @@ def load_area_tree():
     sys.modules['homeassistant.const'] = types.ModuleType('homeassistant.const')
     sys.modules['homeassistant.const'].EVENT_CALL_SERVICE = 'call_service'
 
+    adv_mod = types.ModuleType('modules.advanced_tracker')
+    class DummyTracker:
+        def __init__(self, *a, **k):
+            self.debug_dir = 'debug'
+            self._debug_counter = 0
+        def process_event(self, *a, **k):
+            self._debug_counter += 1
+        def step(self):
+            pass
+    adv_mod.init_from_yaml = lambda *a, **k: DummyTracker()
+    adv_mod.MultiPersonTracker = DummyTracker
+    sys.modules['modules.advanced_tracker'] = adv_mod
+
     tracker_mod = types.ModuleType('tracker')
     tracker_mod.TrackManager = object
     tracker_mod.Track = object


### PR DESCRIPTION
## Summary
- wire AreaTree to `modules.advanced_tracker` and output debug frames
- mock advanced tracker in test fixtures
- document new tracker

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850519c3b94832d8adec6478aba8d75