### PR TITLE
Add light calibration and Hue driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ the full implementations.
   is associated with.
 - **`TelevisionDriver`** – Controls televisions through a `media_player` entity
   and reports the currently playing media.
+- **`HueLight`** – Light driver for Philips Hue bulbs. Uses color calibration so
+  lights with different hardware show consistent colors.
 
 ## Event and Rule Workflow
 
@@ -179,6 +181,9 @@ Key principles:
 * **Color does not imply power.** Changing `rgb_color` or `color_temp` merely
   updates the color; it does not affect the `status` flag. This prevents color
   adjustments from accidentally turning lights on or off.
+* **Color calibration.** Light drivers can apply per-device calibration
+  profiles so that the same RGB values appear consistent across different
+  hardware.
 * **Function-based scopes.** Scope and state logic is delegated to functions
   referenced by name, letting complex behavior live in Python while YAML stays
   declarative.

--- a/tests/test_additional_drivers.py
+++ b/tests/test_additional_drivers.py
@@ -44,3 +44,18 @@ def test_television_driver_on_off():
     tv.set_state({'status': 0})
     assert calls == ['on', 'off']
 
+
+def test_hue_light_calibration():
+    area_tree = load_area_tree()
+    # adjust profile so test has predictable output
+    area_tree.COLOR_PROFILES['hue'] = [0.5, 1.0, 1.0]
+    calls = []
+    area_tree.light = types.SimpleNamespace(
+        turn_on=lambda **kw: calls.append(kw),
+        turn_off=lambda **kw: None
+    )
+    HueLight = area_tree.HueLight
+    light = HueLight('library_lamp')
+    light.apply_values(rgb_color=[100, 100, 100])
+    assert calls and calls[0]['rgb_color'] == [50, 100, 100]
+

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -37,6 +37,12 @@ def load_area_tree():
         sys.modules['homeassistant'] = types.ModuleType('homeassistant')
         sys.modules['homeassistant.const'] = types.ModuleType('homeassistant.const')
         sys.modules['homeassistant.const'].EVENT_CALL_SERVICE = 'call_service'
+        util_mod = types.ModuleType('homeassistant.util')
+        color_mod = types.ModuleType('homeassistant.util.color')
+        color_mod.color_temperature_to_rgb = lambda x: (0, 0, 0)
+        util_mod.color = color_mod
+        sys.modules['homeassistant.util'] = util_mod
+        sys.modules['homeassistant.util.color'] = color_mod
 
     tracker_mod = types.ModuleType('tracker')
     tracker_mod.TrackManager = object


### PR DESCRIPTION
## Summary
- calibrate RGB values per light type
- introduce `HueLight` driver using color calibration
- document color calibration in design philosophy
- test Hue light calibration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850602e3c40832d9a4803149f01a614