### PR TITLE
Fix device_name warning message

### DIFF
--- a/area_tree.py
+++ b/area_tree.py
@@ -171,7 +171,7 @@ def create_event(**kwargs):
         event_manager.create_event(event)
 
     else:
-        log.warning(f"No devic_name in serice created event {kwargs}")
+        log.warning(f"No device_name in service-created event {kwargs}")
 
 
 @service


### PR DESCRIPTION
## Summary
- fix typo in `create_event` warning about missing `device_name`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685061215660832d9942ca8d4762fe93