### PR TITLE
Fix brightness key typo

### DIFF
--- a/area_tree.py
+++ b/area_tree.py
@@ -525,9 +525,9 @@ def get_time_based_state(device, scope, *args):
             if "brightness" in scope_state:
                 current_brightness = scope_state["brightness"]
                 if current_brightness > 50:
-                    state["brightess"] = current_brightness - 5
+                    state["brightness"] = current_brightness - 5
             else:
-                state["brightess"] = 50
+                state["brightness"] = 50
 
     if "status" in scope_state:
         if scope_state["status"]:


### PR DESCRIPTION
## Summary
- fix typo in `get_time_based_state` returning state with `brightness`
- install deps and run tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850612315c8832d866b375482d4a8d7