### PR TITLE
Fix impulse parameter typo

### DIFF
--- a/modules/tracker.py
+++ b/modules/tracker.py
@@ -19,7 +19,7 @@ def are_events_same(event1, event2):
 
 
 class Event:
-    def __init__(self, area, inpulse=True):
+    def __init__(self, area, impulse=True):
         """
         Creates a new event starting at now.
         An Event is an impulse if there is no status on ongoing presence.
@@ -29,12 +29,12 @@ class Event:
 
         Parameters:
             area (str): The area associated with the event.
-            inpulse (bool, optional): Determines if the Event is ongoing or not.
+            impulse (bool, optional): Determines if the Event is ongoing or not.
         """
         self.first_presence_time=time.time()
         self.area = area
         self.last_rising_edge_time=self.first_presence_time
-        if not inpulse:
+        if not impulse:
             self.last_falling_edge_time=self.first_presence_time
         else :
             self.last_falling_edge_time=None


### PR DESCRIPTION
## Summary
- rename `inpulse` to `impulse` in Event initialization
- update documentation and logic accordingly

## Testing
- `pip install -r requirements.txt`
- `pip install homeassistant`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68506126413c832db7612863a349e6da