### PR TITLE
Fix EvalLocalVar input driver

### DIFF
--- a/area_tree.py
+++ b/area_tree.py
@@ -1401,6 +1401,13 @@ class AreaTree:
                                         new_input = None
                                         for key, factory in INPUT_DRIVERS.items():
                                             if key in device_id:
+                                                if not callable(factory) and hasattr(factory, 'get'):
+                                                    try:
+                                                        tmp_factory = factory.get()
+                                                        if callable(tmp_factory):
+                                                            factory = tmp_factory
+                                                    except Exception:
+                                                        pass
                                                 new_input = factory(input_type, device_id)
                                                 log.info(f"Creating input device: {device_id} using {key}")
                                                 break


### PR DESCRIPTION
## Summary
- unwrap EvalLocalVar drivers before calling them

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68507a5aca74832d9fcc45cd830d02b1