### PR TITLE
Add motion sensor integration tests

### DIFF
--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -125,3 +125,27 @@ def test_global_cache_copy():
     ret = get_cached_last_set_state()
     ret['status'] = 0
     assert get_cached_last_set_state() == sample
+
+
+def test_add_to_cache_initial_and_merge():
+    d = Device(DummyDriver('light'))
+    d.add_to_cache({'status': 1})
+    assert d.last_state is None
+    assert d.cached_state == {'status': 1}
+
+    d.add_to_cache({'brightness': 50})
+    assert d.last_state == {'status': 1}
+    assert d.cached_state == {'status': 1, 'brightness': 50}
+
+
+def test_get_last_state_after_cache_updates():
+    d = Device(DummyDriver('light'))
+    d.add_to_cache({'status': 1})
+    d.add_to_cache({'status': 0})
+    last = d.get_last_state()
+    assert last == {'name': 'light', 'status': 1}
+
+
+def test_set_cached_last_state_none():
+    set_cached_last_set_state(None, None)
+    assert get_cached_last_set_state() is None

--- a/tests/test_motion_sensors.py
+++ b/tests/test_motion_sensors.py
@@ -1,0 +1,71 @@
+import types
+from .conftest import load_area_tree, _stub_decorator
+
+
+def setup_motion_env():
+    mod = load_area_tree()
+    # stub pyscript decorators
+    mod.state_trigger = _stub_decorator
+    mod.service = _stub_decorator
+    mod.event_trigger = _stub_decorator
+    mod.pyscript_compile = _stub_decorator
+    # required globals
+    mod.global_triggers = []
+    mod.input_boolean = types.SimpleNamespace(motion_sensor_mode='on')
+    mod.light = types.SimpleNamespace(turn_on=lambda **kw: None,
+                                      turn_off=lambda **kw: None)
+    mod.tracker_manager = types.SimpleNamespace(process_event=lambda *a, **k: None)
+    area_tree = mod.AreaTree('layout.yml')
+    mod.area_tree = area_tree
+    mod.event_manager = mod.EventManager('rules.yml', area_tree)
+    return mod
+
+
+def get_kitchen_lights(area_tree):
+    area = area_tree.get_area('kitchen')
+    return [c for c in area.get_children() if c.name.startswith('kauf')]
+
+
+def test_motion_sensor_turns_on_lights():
+    mod = setup_motion_env()
+    area_tree = mod.get_area_tree()
+    lights = get_kitchen_lights(area_tree)
+    # ensure cache empty
+    for l in lights:
+        assert l.cached_state is None
+    mod.event_manager.create_event({'device_name': 'motion_sensor_kitchen',
+                                    'tags': ['on', 'motion_occupancy']})
+    for l in lights:
+        assert l.cached_state is not None
+
+
+def test_motion_sensor_respects_freeze():
+    mod = setup_motion_env()
+    area_tree = mod.get_area_tree()
+    lights = get_kitchen_lights(area_tree)
+    mod.freeze_area('kitchen')
+    mod.event_manager.create_event({'device_name': 'motion_sensor_kitchen',
+                                    'tags': ['on', 'motion_occupancy']})
+    for l in lights:
+        assert not l.cached_state
+    mod.unfreeze_area('kitchen')
+    mod.event_manager.create_event({'device_name': 'motion_sensor_kitchen',
+                                    'tags': ['on', 'motion_occupancy']})
+    for l in lights:
+        assert l.cached_state is not None
+
+
+def test_motion_sensor_mode_off_disables():
+    mod = setup_motion_env()
+    area_tree = mod.get_area_tree()
+    lights = get_kitchen_lights(area_tree)
+    mod.input_boolean.motion_sensor_mode = 'off'
+    mod.event_manager.create_event({'device_name': 'motion_sensor_kitchen',
+                                    'tags': ['on', 'motion_occupancy']})
+    for l in lights:
+        assert not l.cached_state
+    mod.input_boolean.motion_sensor_mode = 'on'
+    mod.event_manager.create_event({'device_name': 'motion_sensor_kitchen',
+                                    'tags': ['on', 'motion_occupancy']})
+    for l in lights:
+        assert l.cached_state is not None


### PR DESCRIPTION
## Summary
- add new test suite covering motion sensor interactions
  - ensure lights turn on
  - verify frozen areas ignore motion
  - respect motion sensor mode setting
- expand caching tests for device state merging and global reset

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68507b7ba5f0832db0582f2c60e65a1b