### PR TITLE
Add additional drivers with tests

### DIFF
--- a/tests/test_additional_drivers.py
+++ b/tests/test_additional_drivers.py
@@ -1,0 +1,53 @@
+import types
+from tests.test_caching import load_area_tree
+
+
+def test_plug_driver_on_off():
+    area_tree = load_area_tree()
+    calls = []
+    area_tree.switch = types.SimpleNamespace(
+        turn_on=lambda **kw: calls.append(("on", kw)),
+        turn_off=lambda **kw: calls.append(("off", kw)),
+    )
+    PlugDriver = area_tree.PlugDriver
+    d = PlugDriver("desk")
+    d.set_state({"status": 1})
+    d.set_state({"status": 0})
+    assert calls[0][0] == "on" and calls[1][0] == "off"
+
+
+def test_contact_sensor_get_state():
+    area_tree = load_area_tree()
+    area_tree.state = types.SimpleNamespace(get=lambda eid: "on")
+    ContactSensorDriver = area_tree.ContactSensorDriver
+    d = ContactSensorDriver("door")
+    state = d.get_state()
+    assert state["contact"] == 1
+
+
+def test_fan_driver_on_off():
+    area_tree = load_area_tree()
+    calls = []
+    area_tree.fan = types.SimpleNamespace(
+        turn_on=lambda **kw: calls.append(("on", kw)),
+        turn_off=lambda **kw: calls.append(("off", kw)),
+    )
+    FanDriver = area_tree.FanDriver
+    d = FanDriver("ceiling")
+    d.set_state({"status": 1})
+    d.set_state({"status": 0})
+    assert calls[0][0] == "on" and calls[1][0] == "off"
+
+
+def test_television_driver_on_off():
+    area_tree = load_area_tree()
+    calls = []
+    area_tree.media_player = types.SimpleNamespace(
+        turn_on=lambda **kw: calls.append(("on", kw)),
+        turn_off=lambda **kw: calls.append(("off", kw)),
+    )
+    TelevisionDriver = area_tree.TelevisionDriver
+    d = TelevisionDriver("tv")
+    d.set_state({"status": 1})
+    d.set_state({"status": 0})
+    assert calls[0][0] == "on" and calls[1][0] == "off"

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -29,6 +29,13 @@ def load_area_tree():
         sys.modules['homeassistant'] = types.ModuleType('homeassistant')
         sys.modules['homeassistant.const'] = types.ModuleType('homeassistant.const')
         sys.modules['homeassistant.const'].EVENT_CALL_SERVICE = 'call_service'
+        util_mod = types.ModuleType('homeassistant.util')
+        util_mod.color = types.SimpleNamespace(
+            color_RGB_to_hs=lambda r, g, b: (0, 0),
+            color_hs_to_RGB=lambda h, s: (0, 0, 0),
+            color_temperature_to_rgb=lambda k: (0, 0, 0),
+        )
+        sys.modules['homeassistant.util'] = util_mod
 
     tracker_mod = types.ModuleType('tracker')
     tracker_mod.TrackManager = object


### PR DESCRIPTION
## Summary
- implement new device drivers: PlugDriver, ContactSensorDriver, FanDriver and TelevisionDriver
- create devices automatically based on `devices.yml`
- stub out `homeassistant.util` functions for tests
- add unit tests covering the new drivers

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68572e8727d8832dad2c278ad5e1eb8f