### PR TITLE
Restore color calibration and Hue light

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,16 @@ the full implementations.
   configured blind height.
 - **`SpeakerDriver`** – Controls media speakers like Google Home. Tracks volume
   and what is currently playing, and allows adjusting volume via `set_state()`.
+- **`PlugDriver`** – Operates smart plugs or switches to turn devices on or off
+  and can report power usage if a sensor is available.
+- **`ContactSensorDriver`** – Wraps door or window sensors providing open/closed
+  events.
+- **`FanDriver`** – Extends `PlugDriver` for fans and can store which window it
+  is associated with.
+- **`TelevisionDriver`** – Controls televisions through a `media_player` entity
+  and reports the currently playing media.
+- **`HueLight`** – Light driver for Philips Hue bulbs. Uses color calibration so
+  lights with different hardware show consistent colors.
 
 ## Event and Rule Workflow
 
@@ -172,6 +182,9 @@ Key principles:
 * **Color does not imply power.** Changing `rgb_color` or `color_temp` merely
   updates the color; it does not affect the `status` flag. This prevents color
   adjustments from accidentally turning lights on or off.
+* **Color calibration.** Light drivers can apply per-device calibration
+  profiles so that the same RGB values appear consistent across different
+  hardware.
 * **Function-based scopes.** Scope and state logic is delegated to functions
   referenced by name, letting complex behavior live in Python while YAML stays
   declarative.

--- a/tests/test_additional_drivers.py
+++ b/tests/test_additional_drivers.py
@@ -51,3 +51,18 @@ def test_television_driver_on_off():
     d.set_state({"status": 1})
     d.set_state({"status": 0})
     assert calls[0][0] == "on" and calls[1][0] == "off"
+
+
+def test_hue_light_calibration():
+    area_tree = load_area_tree()
+    # adjust profile so test has predictable output
+    area_tree.COLOR_PROFILES["hue"] = [0.5, 1.0, 1.0]
+    calls = []
+    area_tree.light = types.SimpleNamespace(
+        turn_on=lambda **kw: calls.append(kw),
+        turn_off=lambda **kw: None,
+    )
+    HueLight = area_tree.HueLight
+    light = HueLight("library_lamp")
+    light.apply_values(rgb_color=[100, 100, 100])
+    assert calls and calls[0]["rgb_color"] == [50, 100, 100]


### PR DESCRIPTION
## Summary
- reintroduce per-device COLOR_PROFILES and `calibrate_rgb` helper
- allow `KaufLight` and new `HueLight` to apply calibration
- detect hue lights when building the area tree
- document Hue light driver and color calibration features
- add regression test verifying calibration behavior

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685732f014a4832db16e02da2ad6346e