### PR TITLE
Enable advanced presence tracker with optimized logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,8 @@ See the [`execute_rule`](area_tree.py) method for the full logic.
 particle-filter based tracker. It follows people through the area graph defined
 in [`connections.yml`](connections.yml) and can output visualization frames. The
 `update_tracker` function in [`area_tree.py`](area_tree.py) feeds motion sensor
-events into the tracker and logs each generated frame.
+events into the tracker and logs frames at a throttled rate so debug logging can
+remain enabled without filling the disk.
 For a thorough explanation of the algorithm and code walkthroughs, see
 [the detailed tracker README](modules/ADVANCED_TRACKER_README.md).
 

--- a/modules/ADVANCED_TRACKER_README.md
+++ b/modules/ADVANCED_TRACKER_README.md
@@ -93,7 +93,10 @@ To enable or disable visual logging, pass `debug=True` and specify a
 folder with names like `frame_000001.png`.  Each image has a corresponding
 `state_000001.json` file produced by `MultiPersonTracker.dump_state()` which
 contains the current estimates and probability distributions for all tracked
-people.
+people.  The tracker caps the number of stored frames (default ``1000``) and
+only saves a new image if at least ``log_interval`` seconds have passed
+(default ``60``) so logging can remain enabled long term without filling up
+disk space.
 
 ## Testing
 


### PR DESCRIPTION
## Summary
- switch `area_tree` to use `modules.advanced_tracker`
- throttle and cap debug image logging in advanced tracker
- keep debug logging enabled in area_tree
- document new tracker logging options

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685736bf1038832dbd4cd70470c453e3