### PR TITLE
Enable async initialization for advanced tracker

### DIFF
--- a/area_tree.py
+++ b/area_tree.py
@@ -96,7 +96,7 @@ def reset():
 
 
 @service
-def init():
+async def init():
     global area_tree
     global event_manager
     global global_triggers
@@ -104,7 +104,7 @@ def init():
     global_triggers = []
     area_tree = AreaTree("./pyscript/layout.yml")
     event_manager = EventManager("./pyscript/rules.yml", area_tree)
-    tracker_manager = init_from_yaml(
+    tracker_manager = await init_from_yaml(
         "./pyscript/connections.yml",
         debug=False,
         debug_dir="pyscript/tracker_debug",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,7 +80,8 @@ def load_area_tree(use_real_drivers: bool | None = None):
     sys.modules['area_tree'] = mod
     exec(code, mod.__dict__)
     if use_real_drivers and hasattr(mod, "init"):
-        mod.init()
+        import asyncio
+        asyncio.run(mod.init())
     return mod
 
 

--- a/tests/test_advanced_tracker.py
+++ b/tests/test_advanced_tracker.py
@@ -4,6 +4,7 @@ import tempfile
 import pytest
 import yaml
 import json
+import asyncio
 
 pytest.importorskip("scipy")
 
@@ -19,12 +20,12 @@ from modules.advanced_tracker import (
 
 class TestAdvancedTracker(unittest.TestCase):
     def test_load_graph(self):
-        graph = load_room_graph_from_yaml('connections.yml')
+        graph = asyncio.run(load_room_graph_from_yaml('connections.yml'))
         self.assertIn('bedroom', graph.get_neighbors('bathroom'))
         self.assertIn('bathroom', graph.get_neighbors('bedroom'))
 
     def test_person_distribution(self):
-        graph = load_room_graph_from_yaml('connections.yml')
+        graph = asyncio.run(load_room_graph_from_yaml('connections.yml'))
         sensor_model = SensorModel()
         tracker = PersonTracker(graph, sensor_model, num_particles=10)
         now = 0.0
@@ -33,7 +34,7 @@ class TestAdvancedTracker(unittest.TestCase):
         self.assertAlmostEqual(sum(dist.values()), 1.0, places=5)
 
     def test_debug_visualization(self):
-        graph = load_room_graph_from_yaml('connections.yml')
+        graph = asyncio.run(load_room_graph_from_yaml('connections.yml'))
         sensor_model = SensorModel()
         with tempfile.TemporaryDirectory() as tmp:
             multi = MultiPersonTracker(graph, sensor_model, debug=True, debug_dir=tmp)
@@ -43,7 +44,7 @@ class TestAdvancedTracker(unittest.TestCase):
         self.assertTrue(any(f.startswith('frame_') and f.endswith('.png') for f in files))
 
     def test_phone_association_and_state(self):
-        graph = load_room_graph_from_yaml('connections.yml')
+        graph = asyncio.run(load_room_graph_from_yaml('connections.yml'))
         sensor_model = SensorModel()
         multi = MultiPersonTracker(graph, sensor_model)
         import random
@@ -63,7 +64,7 @@ class TestAdvancedTracker(unittest.TestCase):
         with open(path, 'r') as f:
             scenario = yaml.safe_load(f)
 
-        graph = load_room_graph_from_yaml(scenario['connections'])
+        graph = asyncio.run(load_room_graph_from_yaml(scenario['connections']))
         sensor_model = SensorModel()
         multi = MultiPersonTracker(graph, sensor_model)
 


### PR DESCRIPTION
## Summary
- load room graphs using asyncio to avoid blocking
- make `init_from_yaml` async
- call `init_from_yaml` with await in `area_tree.init`
- adapt tests for new async APIs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685747409648832d9cdeea7ce6bf3bb0