### PR TITLE
Add log_state_change helper

### DIFF
--- a/area_tree.py
+++ b/area_tree.py
@@ -2,6 +2,7 @@ import yaml
 from collections import defaultdict
 import copy
 import time
+from modules.logger import log_state_change
 from pyscript.k_to_rgb import convert_K_to_RGB
 from homeassistant.const import EVENT_CALL_SERVICE
 try:
@@ -1510,16 +1511,17 @@ class Device:
     def add_to_cache(self, state):
         # Remove keys that don't apply to driver (buttons don't have rgb color etc...)
         if state is not None :
-            state=self.filter_state(state)
+            state = self.filter_state(state)
 
+            old_state = copy.deepcopy(self.cached_state)
             self.last_state = self.cached_state
-            new_state=copy.deepcopy(self.cached_state) # Set cached state as old state
-            if new_state is None :
+            new_state = copy.deepcopy(self.cached_state)  # Set cached state as old state
+            if new_state is None:
                 new_state = {}
             for key, val in state.items():
-                new_state[key] = copy.deepcopy(val) #update with new values
+                new_state[key] = copy.deepcopy(val)  # update with new values
             self.cached_state = new_state
-            log.info(f"add_to_cache: Added {state} to {self.last_state} to create Cached state: {self.cached_state}")
+            log_state_change(old_state, self.cached_state)
 
     def input_trigger(self, tags):
         global event_manager
@@ -1530,7 +1532,7 @@ class Device:
         event_manager.create_event(event)
 
     def set_state(self, state):
-        log.info(f"Setting state: {state} on {self.name}")
+        log_state_change(self.cached_state, state)
         if not self.locked:
             #TODO: FIXME this is a hack, should be done on driver side
             color_type=None
@@ -1554,10 +1556,9 @@ class Device:
                         del state["rgb_color"]
                 log.info(f"filled out state from cache: {state}")
 
-                applied_state=self.driver.set_state(state)
-                log.info(f"Applied state: {applied_state}")
+                applied_state = self.driver.set_state(state)
+                log_state_change(self.cached_state, applied_state)
                 self.add_to_cache(applied_state)
-                log.info(f"Updated cache: {self.cached_state}")
         else :
             if get_verbose_mode():
                 log.info(f"Device {self.name} is locked, not setting state {state}")

--- a/modules/logger.py
+++ b/modules/logger.py
@@ -69,9 +69,21 @@ class Logger:
             log.error(self._format(self.component, msg, data))
 
 
+def log_state_change(old_state: dict | None, new_state: dict | None) -> None:
+    """Log only the keys whose values changed between two state dictionaries."""
+    old_state = old_state or {}
+    new_state = new_state or {}
+    changed = {k: v for k, v in new_state.items() if old_state.get(k) != v}
+    for k in old_state:
+        if k not in new_state:
+            changed[k] = None
+    if changed:
+        log.info(f"State change: {changed}")
+
+
 def get_logger(component: str) -> Logger:
     """Return a ``Logger`` for ``component``."""
     return Logger(component)
 
 
-__all__ = ["get_logger", "set_level", "Logger"]
+__all__ = ["get_logger", "set_level", "Logger", "log_state_change"]


### PR DESCRIPTION
## Summary
- add `log_state_change` helper in logger
- highlight differences when setting state or caching device state

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68581e0c12e4832daf876e2acc495abf