### PR TITLE
Add dated debug events for advanced tracker

### DIFF
--- a/modules/ADVANCED_TRACKER_README.md
+++ b/modules/ADVANCED_TRACKER_README.md
@@ -99,8 +99,11 @@ associated person.  The current state of all trackers can be inspected with
 `dump_state()` which returns JSON.
 
 To enable or disable visual logging, pass `debug=True` and specify a
-`debug_dir` when calling `init_from_yaml()`.  Images are written to that
-folder with names like `frame_000001.png`.
+`debug_dir` when calling `init_from_yaml()`.  Frames are saved under
+time-stamped folders inside `debug_dir` using the pattern
+`YYYY/MM/DD/HHMMSS/frame_000001.png`.  A new folder is created whenever no
+event has occurred for `event_window` seconds (default `600`), making it
+easy to inspect separate sequences.
 
 ## Testing
 


### PR DESCRIPTION
## Summary
- support event-windowed debug directories in `advanced_tracker`
- add overlay information to debug images
- document the new debug folder hierarchy
- test single and multiple debug event directories

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858947b5f50832db504a8e726202102