### PR TITLE
Improve advanced tracker event log visuals

### DIFF
--- a/modules/ADVANCED_TRACKER_README.md
+++ b/modules/ADVANCED_TRACKER_README.md
@@ -44,9 +44,10 @@ the distribution over time.  Call `dump_state()` to retrieve a JSON summary
 of all people and phones.
 Each debug frame includes a side panel with a legend explaining that node
 color represents the tracked person and the alpha channel indicates the
-probability of presence. The panel also logs every sensor event along with
-the current location estimate so you can follow the sequence that produced
-the plot.
+probability of presence. The panel also logs every sensor event with a
+timestamp alongside the current location estimate so you can follow the
+sequence that produced the plot. The log now appears on the left of the
+image and the triggered room is highlighted in yellow for that frame.
 
 ## Example Walk‑through
 

--- a/tests/test_advanced_tracker.py
+++ b/tests/test_advanced_tracker.py
@@ -57,6 +57,14 @@ class TestAdvancedTracker(unittest.TestCase):
                 any(f.startswith('frame_') and f.endswith('.png') for f in contents)
             )
 
+    def test_event_log_includes_timestamp(self):
+        graph = load_room_graph_from_yaml('connections.yml')
+        sensor_model = SensorModel()
+        multi = MultiPersonTracker(graph, sensor_model, debug=True)
+        multi.process_event('p1', 'bedroom', timestamp=5.0)
+        self.assertTrue(multi._event_history)
+        self.assertIn('5.0', multi._event_history[0])
+
     def test_multiple_event_directories(self):
         graph = load_room_graph_from_yaml('connections.yml')
         sensor_model = SensorModel()


### PR DESCRIPTION
## Summary
- clarify README for advanced tracker
- show sensor event timestamps in debug event log
- highlight the current sensor node in yellow
- bump font sizes by 10%
- move the log to the left side
- verify timestamps via unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6858aca96258832dbd82986aace8043c