### PR TITLE
Improve debug legend of advanced tracker

### DIFF
--- a/modules/advanced_tracker.py
+++ b/modules/advanced_tracker.py
@@ -433,9 +433,21 @@ class MultiPersonTracker:
         # Legend for node colors and alpha
         legend_lines = [
             "Legend:",
-            "  Node color: person id (red, green, blue)",
+            "  Node color: person id",
             "  Alpha: probability",
         ]
+
+        color_names = {0: "red", 1: "green", 2: "blue"}
+        for idx, pid in enumerate(self.people.keys()):
+            color_name = color_names.get(idx % 3, "unknown")
+            legend_lines.append(f"  {pid}: {color_name}")
+
+        legend_lines.append("  solid line: estimated path")
+        legend_lines.append("  dashed orange: true path (tests only)")
+
+        # Store for unit tests
+        self._last_legend_lines = legend_lines
+
         for idx, line in enumerate(legend_lines):
             fig.text(
                 0.72,

--- a/tests/test_advanced_tracker.py
+++ b/tests/test_advanced_tracker.py
@@ -57,6 +57,11 @@ class TestAdvancedTracker(unittest.TestCase):
                 any(f.startswith('frame_') and f.endswith('.png') for f in contents)
             )
 
+            legend = getattr(multi, '_last_legend_lines', [])
+            self.assertTrue(any(line.strip().startswith('p1:') for line in legend))
+            self.assertTrue(any('solid line: estimated path' in line for line in legend))
+            self.assertTrue(any('dashed orange: true path (tests only)' in line for line in legend))
+
     def test_event_log_includes_timestamp(self):
         graph = load_room_graph_from_yaml('connections.yml')
         sensor_model = SensorModel()


### PR DESCRIPTION
## Summary
- enrich legend with per-person colors
- describe estimated and true path line styles
- expose legend text for tests
- test legend contents in debug visualization

## Testing
- `pytest -q tests/test_advanced_tracker.py::TestAdvancedTracker::test_debug_visualization -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6858b042eba0832da375f0fcdfab0571