### PR TITLE
Add multi-room tracker test scenarios

### DIFF
--- a/tests/scenarios/bedroom_loop.yml
+++ b/tests/scenarios/bedroom_loop.yml
@@ -1,0 +1,12 @@
+connections: tests/scenarios/simple_connections.yml
+persons:
+  - id: p1
+    events:
+      - time: 0
+        room: bedroom
+      - time: 30
+        room: hallway
+      - time: 60
+        room: bedroom
+expected_final:
+  p1: bedroom

--- a/tests/scenarios/cross_walk.yml
+++ b/tests/scenarios/cross_walk.yml
@@ -1,0 +1,21 @@
+connections: tests/scenarios/simple_connections.yml
+persons:
+  - id: alice
+    events:
+      - time: 0
+        room: bedroom
+      - time: 15
+        room: hallway
+      - time: 30
+        room: kitchen
+  - id: bob
+    events:
+      - time: 5
+        room: kitchen
+      - time: 20
+        room: hallway
+      - time: 35
+        room: bedroom
+expected_final:
+  alice: hallway
+  bob: bedroom

--- a/tests/scenarios/kitchen_to_bedroom.yml
+++ b/tests/scenarios/kitchen_to_bedroom.yml
@@ -1,0 +1,12 @@
+connections: tests/scenarios/simple_connections.yml
+persons:
+  - id: p1
+    events:
+      - time: 0
+        room: kitchen
+      - time: 15
+        room: hallway
+      - time: 30
+        room: bedroom
+expected_final:
+  p1: bedroom


### PR DESCRIPTION
## Summary
- expand advanced tracker scenarios with longer multi-room walks
- cover round trip, kitchen to bedroom path, and cross-over of two people

## Testing
- `pip install -r requirements.txt`
- `pip install homeassistant`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858b157c904832d845db359c01f3d66