### PR TITLE
Add highlight probabilities to tracker visualization

### DIFF
--- a/modules/advanced_tracker.py
+++ b/modules/advanced_tracker.py
@@ -176,9 +176,26 @@ class MultiPersonTracker:
         self.debug = debug
         self.debug_dir = debug_dir
         self._debug_counter = 0
+        self._highlight_room: Optional[str] = None
         if self.debug:
             os.makedirs(self.debug_dir, exist_ok=True)
             self._layout = nx.kamada_kawai_layout(self.room_graph.graph)
+
+    def set_highlight_room(self, room_id: Optional[str]) -> None:
+        """Set the room for probability highlighting during visualization."""
+        self._highlight_room = room_id
+
+    def _format_highlight_probabilities(self) -> Optional[str]:
+        """Return formatted probability list for the highlighted room."""
+        if not self._highlight_room:
+            return None
+        entries = []
+        for pid, tracker in self.trackers.items():
+            prob = tracker.distribution().get(self._highlight_room, 0.0)
+            entries.append((prob, pid))
+        entries.sort(reverse=True)
+        lines = [f"{pid}: {int(prob * 100 + 0.5)}%" for prob, pid in entries]
+        return "\n".join(lines)
 
     def process_event(self, person_id: str, room_id: str, timestamp: Optional[float] = None) -> None:
         now = time.time() if timestamp is None else timestamp
@@ -281,6 +298,17 @@ class MultiPersonTracker:
             )
         ax.set_title(f"t={current_time:.1f}")
         ax.axis('off')
+
+        highlight_text = self._format_highlight_probabilities()
+        if highlight_text:
+            fig.text(
+                0.98,
+                0.02,
+                highlight_text,
+                ha="right",
+                va="bottom",
+                fontsize=8,
+            )
         filename = os.path.join(self.debug_dir, f"frame_{self._debug_counter:06d}.png")
         plt.savefig(filename)
         plt.close(fig)

--- a/tests/test_advanced_tracker.py
+++ b/tests/test_advanced_tracker.py
@@ -60,6 +60,21 @@ class TestAdvancedTracker(unittest.TestCase):
             self.assertEqual(state['phones']['ph1']['last_room'], 'bedroom')
             self.assertIn('estimate', state['people']['alice'])
 
+    def test_highlight_format(self):
+        graph = load_room_graph_from_yaml('connections.yml')
+        sensor_model = SensorModel()
+        with tempfile.TemporaryDirectory() as tmp:
+            multi = MultiPersonTracker(graph, sensor_model, debug=True, debug_dir=tmp)
+            import random
+            random.seed(0)
+            multi.set_highlight_room('bedroom')
+            multi.process_event('p1', 'bedroom', timestamp=0.0)
+            multi.process_event('p2', 'kitchen', timestamp=0.0)
+            multi.step()
+            text = multi._format_highlight_probabilities()
+            self.assertIsNotNone(text)
+            self.assertTrue(text.splitlines()[0].startswith('p1:'))
+
     def _run_yaml_scenario(self, path: str):
         with open(path, 'r') as f:
             scenario = yaml.safe_load(f)


### PR DESCRIPTION
## Summary
- compute probabilities for a highlighted room
- show sorted list on debug visualizations
- test probability formatting

## Testing
- `pip install -r requirements.txt`
- `pip install homeassistant`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858b34f0408832db81ea934607fa44f