### PR TITLE
Add presence sensor support to advanced tracker

### DIFF
--- a/modules/ADVANCED_TRACKER_README.md
+++ b/modules/ADVANCED_TRACKER_README.md
@@ -15,11 +15,14 @@ weight is adjusted based on the `SensorModel`.
 
 ### Sensor Model
 
-`SensorModel` records the last time a motion sensor fired in each room and
-computes the probability that a person is still there.  The probability
-drops from `1.0` at the time of the event down to a small floor value over
-a configurable cooldown (default 7 minutes).  When a new sensor event is
-processed the corresponding probability spikes back to `1.0`.
+`SensorModel` records motion events and optional presence sensor states for
+each room.  Motion sensors behave like real hardware—they trigger once and
+then remain "on" for 7 minutes before resetting.  The model decays the
+probability of someone still being in the room from `1.0` down to a small
+floor value over this cooldown period.  Presence sensors, if available,
+override the probability entirely: ``True`` means the room is occupied and
+``False`` means it is empty.  A motion event or a ``True`` presence update
+resets the cooldown timer.
 
 ### Particle Updates
 

--- a/tests/test_advanced_tracker.py
+++ b/tests/test_advanced_tracker.py
@@ -60,6 +60,13 @@ class TestAdvancedTracker(unittest.TestCase):
             self.assertEqual(state['phones']['ph1']['last_room'], 'bedroom')
             self.assertIn('estimate', state['people']['alice'])
 
+    def test_sensor_model_presence(self):
+        model = SensorModel()
+        model.set_presence('bedroom', True, timestamp=0.0)
+        self.assertEqual(model.likelihood_still_present('bedroom', current_time=10.0), 1.0)
+        model.set_presence('bedroom', False, timestamp=20.0)
+        self.assertEqual(model.likelihood_still_present('bedroom', current_time=20.0), 0.0)
+
     def _run_yaml_scenario(self, path: str):
         with open(path, 'r') as f:
             scenario = yaml.safe_load(f)


### PR DESCRIPTION
## Summary
- support presence sensors in `SensorModel` and `MultiPersonTracker`
- document presence sensor behaviour
- test new presence behaviour

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858b3396bf4832d9c278da76c733e6d