### PR TITLE
Preserve tracker debug images under persistent directory

### DIFF
--- a/tests/test_advanced_tracker.py
+++ b/tests/test_advanced_tracker.py
@@ -5,6 +5,13 @@ import pytest
 import yaml
 import json
 
+
+def _get_debug_dir(name: str):
+    base = os.environ.get("TEST_DEBUG_DIR", os.path.join("tracker_debug", "plots"))
+    path = os.path.join(base, name)
+    os.makedirs(path, exist_ok=True)
+    return path, lambda: None
+
 pytest.importorskip("scipy")
 
 from modules.advanced_tracker import (
@@ -35,30 +42,32 @@ class TestAdvancedTracker(unittest.TestCase):
     def test_debug_visualization(self):
         graph = load_room_graph_from_yaml('connections.yml')
         sensor_model = SensorModel()
-        with tempfile.TemporaryDirectory() as tmp:
-            multi = MultiPersonTracker(graph, sensor_model, debug=True, debug_dir=tmp)
-            multi.process_event('p1', 'bedroom', timestamp=0.0)
-            multi.step()
-            files = sorted(os.listdir(tmp))
+        debug_dir, cleanup = _get_debug_dir('test_debug_visualization')
+        multi = MultiPersonTracker(graph, sensor_model, debug=True, debug_dir=debug_dir)
+        multi.process_event('p1', 'bedroom', timestamp=0.0)
+        multi.step()
+        files = sorted(os.listdir(debug_dir))
+        cleanup()
         self.assertTrue(any(f.startswith('frame_') and f.endswith('.png') for f in files))
 
     def test_phone_association_and_state(self):
         graph = load_room_graph_from_yaml('connections.yml')
         sensor_model = SensorModel()
-        with tempfile.TemporaryDirectory() as tmp:
-            multi = MultiPersonTracker(graph, sensor_model, debug=True, debug_dir=tmp)
-            import random
-            random.seed(0)
-            multi.add_phone('ph1')
-            multi.associate_phone('ph1', 'alice')
-            multi.process_phone_data('ph1', 'bedroom', timestamp=0.0)
-            multi.step()
-            self.assertIn('alice', multi.people)
-            self.assertEqual(multi.people['alice'].phones, ['ph1'])
-            state = json.loads(multi.dump_state())
-            self.assertEqual(state['phones']['ph1']['person'], 'alice')
-            self.assertEqual(state['phones']['ph1']['last_room'], 'bedroom')
-            self.assertIn('estimate', state['people']['alice'])
+        debug_dir, cleanup = _get_debug_dir('test_phone_state')
+        multi = MultiPersonTracker(graph, sensor_model, debug=True, debug_dir=debug_dir)
+        import random
+        random.seed(0)
+        multi.add_phone('ph1')
+        multi.associate_phone('ph1', 'alice')
+        multi.process_phone_data('ph1', 'bedroom', timestamp=0.0)
+        multi.step()
+        self.assertIn('alice', multi.people)
+        self.assertEqual(multi.people['alice'].phones, ['ph1'])
+        state = json.loads(multi.dump_state())
+        self.assertEqual(state['phones']['ph1']['person'], 'alice')
+        self.assertEqual(state['phones']['ph1']['last_room'], 'bedroom')
+        self.assertIn('estimate', state['people']['alice'])
+        cleanup()
 
     def test_sensor_model_presence(self):
         model = SensorModel()
@@ -69,17 +78,18 @@ class TestAdvancedTracker(unittest.TestCase):
     def test_highlight_format(self):
         graph = load_room_graph_from_yaml('connections.yml')
         sensor_model = SensorModel()
-        with tempfile.TemporaryDirectory() as tmp:
-            multi = MultiPersonTracker(graph, sensor_model, debug=True, debug_dir=tmp)
-            import random
-            random.seed(0)
-            multi.set_highlight_room('bedroom')
-            multi.process_event('p1', 'bedroom', timestamp=0.0)
-            multi.process_event('p2', 'kitchen', timestamp=0.0)
-            multi.step()
-            text = multi._format_highlight_probabilities()
-            self.assertIsNotNone(text)
-            self.assertTrue(text.splitlines()[0].startswith('p1:'))
+        debug_dir, cleanup = _get_debug_dir('test_highlight_format')
+        multi = MultiPersonTracker(graph, sensor_model, debug=True, debug_dir=debug_dir)
+        import random
+        random.seed(0)
+        multi.set_highlight_room('bedroom')
+        multi.process_event('p1', 'bedroom', timestamp=0.0)
+        multi.process_event('p2', 'kitchen', timestamp=0.0)
+        multi.step()
+        text = multi._format_highlight_probabilities()
+        self.assertIsNotNone(text)
+        self.assertTrue(text.splitlines()[0].startswith('p1:'))
+        cleanup()
 
     def _run_yaml_scenario(self, path: str):
         with open(path, 'r') as f:
@@ -87,38 +97,40 @@ class TestAdvancedTracker(unittest.TestCase):
 
         graph = load_room_graph_from_yaml(scenario['connections'])
         sensor_model = SensorModel()
-        with tempfile.TemporaryDirectory() as tmp:
-            multi = MultiPersonTracker(graph, sensor_model, debug=True, debug_dir=tmp)
+        debug_dir, cleanup = _get_debug_dir(os.path.basename(path).replace('.yml', ''))
+        multi = MultiPersonTracker(graph, sensor_model, debug=True, debug_dir=debug_dir)
 
-            # Build mapping of time -> list of (pid, room)
-            time_events = {}
-            for person in scenario.get('persons', []):
-                pid = person['id']
-                for ev in person.get('events', []):
-                    t = ev['time']
-                    time_events.setdefault(t, []).append((pid, ev['room']))
+        # Build mapping of time -> list of (pid, room)
+        time_events = {}
+        for person in scenario.get('persons', []):
+            pid = person['id']
+            for ev in person.get('events', []):
+                t = ev['time']
+                time_events.setdefault(t, []).append((pid, ev['room']))
 
-            random_seed = scenario.get('seed', 0)
-            import random
-            random.seed(random_seed)
+        random_seed = scenario.get('seed', 0)
+        import random
+        random.seed(random_seed)
 
-            max_t = max(time_events) if time_events else 0
+        max_t = max(time_events) if time_events else 0
 
-            current = 0
-            while current <= max_t:
-                events = time_events.get(current, [])
-                updated = set()
-                for pid, room in events:
-                    multi.process_event(pid, room, timestamp=current)
-                    updated.add(pid)
+        current = 0
+        while current <= max_t:
+            events = time_events.get(current, [])
+            updated = set()
+            for pid, room in events:
+                multi.process_event(pid, room, timestamp=current)
+                updated.add(pid)
 
-                for pid, tracker in multi.trackers.items():
-                    if pid not in updated:
-                        tracker.update(current)
+            for pid, tracker in multi.trackers.items():
+                if pid not in updated:
+                    tracker.update(current)
 
-                current += 1
+            current += 1
 
-            return multi.estimate_locations(), scenario.get('expected_final', {})
+        result = multi.estimate_locations()
+        cleanup()
+        return result, scenario.get('expected_final', {})
 
     def test_yaml_scenarios(self):
         scenario_dir = os.path.join('tests', 'scenarios')


### PR DESCRIPTION
## Summary
- default `_get_debug_dir` to `tracker_debug/plots`
- always keep debug images for tests

## Testing
- `pytest tests/test_advanced_tracker.py::TestAdvancedTracker::test_debug_visualization -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6858b5dc5274832da4bc42780d4c8dc3