### PR TITLE
Improve tracker event handling

### DIFF
--- a/modules/advanced_tracker.py
+++ b/modules/advanced_tracker.py
@@ -119,16 +119,23 @@ class PersonTracker:
             self.particles.append(Particle(room))
 
     def update(self, current_time: float, sensor_room: Optional[str] = None) -> None:
+        """Advance the particle filter by one timestep."""
+
+        move_particles = True
         if sensor_room is not None:
             self.last_sensor_room = sensor_room
             self.last_sensor_time = current_time
             self.sensor_model.record_trigger(sensor_room, current_time)
+            for p in self.particles:
+                p.room = sensor_room
+            move_particles = False
 
         for p in self.particles:
-            p.move(self.room_graph)
+            if move_particles:
+                p.move(self.room_graph)
             weight = self.sensor_model.likelihood_still_present(p.room, current_time)
             if self.last_sensor_room and p.room == self.last_sensor_room:
-                weight *= 1.5
+                weight *= 2.0
             p.weight = weight
 
         # Resample


### PR DESCRIPTION
## Summary
- keep all particles in the triggering room for the current step
- give recent sensor rooms higher weight during resampling

## Testing
- `pytest tests/test_advanced_tracker.py::TestAdvancedTracker::test_yaml_scenarios -q` *(fails: AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_6858ef7acac0832da169b35099dfd712