### PR TITLE
Update README for Pyscript module path

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,8 +203,14 @@ Install dependencies with:
 pip install -r requirements.txt
 ```
 
-Copy the YAML files and Python modules into your Home Assistant `pyscript` directory. After reloading Pyscript, call the `init` service to build the area tree and start processing events. Services like `create_event` can be used to simulate button presses or other triggers.
-The new `freeze_area` and `unfreeze_area` services allow you to temporarily lock an area so lights ignore any events until unfrozen.
+Copy the YAML files and Python modules into your Home Assistant `pyscript`
+directory. Helper modules such as `logger.py` must live under
+`<config>/pyscript/modules/` (or enable `allow_all_imports` in Pyscript) so they
+can be imported. After copying new modules, reload Pyscript and call the `init`
+service to build the area tree and start processing events. Services like
+`create_event` can be used to simulate button presses or other triggers. The new
+`freeze_area` and `unfreeze_area` services allow you to temporarily lock an area
+so lights ignore any events until unfrozen.
 
 Refer back to [Event and Rule Workflow](#event-and-rule-workflow) to understand how a service call becomes an action inside an area.
 


### PR DESCRIPTION
## Summary
- clarify that helper modules must live in `<config>/pyscript/modules/` or enable `allow_all_imports`
- mention reloading Pyscript after copying new modules

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a067238f8832d92a70b1831e10954