### PR TITLE
Add scenario name support for debug output

### DIFF
--- a/tests/scenarios/backtrack_walk.yml
+++ b/tests/scenarios/backtrack_walk.yml
@@ -1,3 +1,4 @@
+name: backtrack_walk
 connections: connections.yml
 persons:
   - id: wanderer

--- a/tests/scenarios/simple_connections.yml
+++ b/tests/scenarios/simple_connections.yml
@@ -1,3 +1,4 @@
+name: simple_connections
 connections:
   - bedroom: hallway
   - hallway: kitchen

--- a/tests/scenarios/simple_walk.yml
+++ b/tests/scenarios/simple_walk.yml
@@ -1,3 +1,4 @@
+name: simple_walk
 connections: tests/scenarios/simple_connections.yml
 persons:
   - id: p1

--- a/tests/scenarios/two_people_apart.yml
+++ b/tests/scenarios/two_people_apart.yml
@@ -1,3 +1,4 @@
+name: two_people_apart
 connections: connections.yml
 persons:
   - id: alice

--- a/tests/scenarios/two_people_crossing.yml
+++ b/tests/scenarios/two_people_crossing.yml
@@ -1,3 +1,4 @@
+name: two_people_crossing
 connections: connections.yml
 persons:
   - id: p1

--- a/tests/scenarios/two_persons.yml
+++ b/tests/scenarios/two_persons.yml
@@ -1,3 +1,4 @@
+name: two_persons
 connections: tests/scenarios/simple_connections.yml
 persons:
   - id: alice

--- a/tests/scenarios/walk_across_house.yml
+++ b/tests/scenarios/walk_across_house.yml
@@ -1,3 +1,4 @@
+name: walk_across_house
 connections: connections.yml
 persons:
   - id: walker

--- a/tests/test_advanced_tracker.py
+++ b/tests/test_advanced_tracker.py
@@ -130,9 +130,11 @@ class TestAdvancedTracker(unittest.TestCase):
         with open(path, 'r') as f:
             scenario = yaml.safe_load(f)
 
+        scenario_name = scenario.get('name') or os.path.splitext(os.path.basename(path))[0]
+
         graph = load_room_graph_from_yaml(scenario['connections'])
         sensor_model = SensorModel()
-        multi = MultiPersonTracker(graph, sensor_model)
+        multi = MultiPersonTracker(graph, sensor_model, test_name=scenario_name)
 
         # Build mapping of time -> list of (pid, room)
         time_events = {}


### PR DESCRIPTION
## Summary
- annotate YAML scenarios with a `name` field
- propagate scenario name in `_run_yaml_scenario`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a1d7533cc832d99dc324e58e981fe