### PR TITLE
Align advanced tracker tests with date-based debug path

### DIFF
--- a/modules/advanced_tracker.py
+++ b/modules/advanced_tracker.py
@@ -237,14 +237,14 @@ class MultiPersonTracker:
 
     def _start_event(self, timestamp: float) -> None:
         """Create a new directory for debug frames for a sensor event."""
+        date_dir = datetime.datetime.fromtimestamp(timestamp).strftime("%Y/%m/%d")
         if self.test_name:
-            # When running under tests, keep all output under a fixed
-            # "tests" date directory and use the test name instead of
-            # timestamp-based subfolders. This keeps paths stable and
-            # ensures subsequent events append to the same directory.
-            path = os.path.join(self.debug_dir, "tests", self.test_name)
+            # When running under tests, keep output under a stable date
+            # directory and use the test name instead of timestamp-based
+            # subfolders. This keeps paths stable and ensures subsequent
+            # events append to the same directory.
+            path = os.path.join(self.debug_dir, date_dir, self.test_name)
         else:
-            date_dir = datetime.datetime.fromtimestamp(timestamp).strftime("%Y/%m/%d")
             event_dir = datetime.datetime.fromtimestamp(timestamp).strftime("%H%M%S")
             path = os.path.join(self.debug_dir, date_dir, event_dir)
         os.makedirs(path, exist_ok=True)

--- a/tests/test_advanced_tracker.py
+++ b/tests/test_advanced_tracker.py
@@ -1,6 +1,7 @@
 import os
 import unittest
 import tempfile
+import datetime
 import pytest
 import yaml
 import json
@@ -51,7 +52,10 @@ class TestAdvancedTracker(unittest.TestCase):
                 if any(f.startswith('frame_') for f in files)
             ]
             self.assertEqual(len(event_dirs), 1)
-            self.assertIn(os.path.join("tests", self._testMethodName), event_dirs[0])
+            date_dir = datetime.datetime.now().strftime('%Y/%m/%d')
+            self.assertTrue(
+                event_dirs[0].endswith(os.path.join(date_dir, self._testMethodName))
+            )
             contents = os.listdir(event_dirs[0])
             self.assertTrue(
                 any(f.startswith('frame_') and f.endswith('.png') for f in contents)
@@ -90,7 +94,10 @@ class TestAdvancedTracker(unittest.TestCase):
                 if any(f.startswith('frame_') for f in files)
             ]
             self.assertEqual(len(event_dirs), 1)
-            self.assertIn(os.path.join("tests", self._testMethodName), event_dirs[0])
+            date_dir = datetime.datetime.fromtimestamp(0).strftime('%Y/%m/%d')
+            self.assertTrue(
+                event_dirs[0].endswith(os.path.join(date_dir, self._testMethodName))
+            )
 
     def test_phone_association_and_state(self):
         graph = load_room_graph_from_yaml('connections.yml')


### PR DESCRIPTION
## Summary
- update `_start_event` to store debug frames under `<date>/<test>`
- check for date-based debug paths in advanced tracker tests

## Testing
- `pytest tests/test_advanced_tracker.py::TestAdvancedTracker::test_debug_visualization -q`
- `pytest tests/test_advanced_tracker.py::TestAdvancedTracker::test_multiple_event_directories -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a1d77bbb4832d8d31dcc59e20bca8