### PR TITLE
Add and update tracker scenarios

### DIFF
--- a/tests/scenarios/missed_event_multi.yml
+++ b/tests/scenarios/missed_event_multi.yml
@@ -1,18 +1,23 @@
-name: simple_walk
+name: missed_event_multi
 connections: tests/scenarios/simple_connections.yml
 persons:
-  - id: p1
+  - id: alice
     events:
       - time: 0
         room: bedroom
       - time: 600
-        room: hallway
-      - time: 1200
         room: kitchen
-      - time: 1800
+      - time: 1200
         room: hallway
-      - time: 2400
+  - id: bob
+    events:
+      - time: 0
+        room: kitchen
+      - time: 600
         room: bedroom
+      - time: 1200
+        room: hallway
 extra_steps: 20
 expected_final:
-  p1: bedroom
+  alice: hallway
+  bob: hallway

--- a/tests/scenarios/missed_event_single.yml
+++ b/tests/scenarios/missed_event_single.yml
@@ -1,18 +1,14 @@
-name: simple_walk
+name: missed_event_single
 connections: tests/scenarios/simple_connections.yml
 persons:
-  - id: p1
+  - id: traveler
     events:
       - time: 0
         room: bedroom
       - time: 600
-        room: hallway
-      - time: 1200
         room: kitchen
-      - time: 1800
+      - time: 1200
         room: hallway
-      - time: 2400
-        room: bedroom
 extra_steps: 20
 expected_final:
-  p1: bedroom
+  traveler: hallway

--- a/tests/scenarios/two_people_apart.yml
+++ b/tests/scenarios/two_people_apart.yml
@@ -6,25 +6,34 @@ persons:
       - time: 0
         room: bedroom
       - time: 300
-        room: bedroom
+        room: bathroom
       - time: 600
-        room: bedroom
+        room: hallway
       - time: 900
-        room: bedroom
+        room: office
       - time: 1200
-        room: bedroom
+        room: laundry_room
+      - time: 1500
+        room: laundry_room
+      - time: 1800
+        room: laundry_room
   - id: bob
     events:
       - time: 0
         room: kitchen
       - time: 300
-        room: kitchen
+        room: dining_room_hallway
       - time: 600
-        room: kitchen
+        room: dining_room_1
       - time: 900
-        room: kitchen
+        room: dining_room_3
       - time: 1200
-        room: kitchen
+        room: living_room_back
+      - time: 1500
+        room: living_room_middle
+      - time: 1800
+        room: living_room_front
+extra_steps: 20
 expected_final:
-  alice: bedroom
-  bob: kitchen
+  alice: laundry_room
+  bob: living_room_front

--- a/tests/scenarios/two_persons.yml
+++ b/tests/scenarios/two_persons.yml
@@ -1,14 +1,23 @@
 name: two_persons
-connections: tests/scenarios/simple_connections.yml
+connections: connections.yml
 persons:
   - id: alice
     events:
       - time: 0
         room: bedroom
+      - time: 300
+        room: hallway
+      - time: 600
+        room: bathroom
   - id: bob
     events:
-      - time: 30
+      - time: 0
         room: kitchen
+      - time: 300
+        room: hallway
+      - time: 600
+        room: office
+extra_steps: 20
 expected_final:
-  alice: bedroom
-  bob: kitchen
+  alice: bathroom
+  bob: office


### PR DESCRIPTION
## Summary
- expand simple walk scenario to include more rooms
- update two_persons scenario so both people meet in the hallway then split
- rework two_people_apart to show simultaneous movement in separate areas
- add missed_event_single and missed_event_multi scenarios for sensor failures

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a398c5380832d9122a972f5387f2d