### PR TITLE
Implement motion-state tracking in SensorModel

### DIFF
--- a/modules/ADVANCED_TRACKER_README.md
+++ b/modules/ADVANCED_TRACKER_README.md
@@ -15,11 +15,12 @@ weight is adjusted based on the `SensorModel`.
 
 ### Sensor Model
 
-`SensorModel` records the last time a motion sensor fired in each room and
-computes the probability that a person is still there.  The probability
-drops from `1.0` at the time of the event down to a small floor value over
-a configurable cooldown (default 7 minutes).  When a new sensor event is
-processed the corresponding probability spikes back to `1.0`.
+`SensorModel` tracks a boolean motion state for every room. When a sensor
+fires the room becomes *active* for the configured cooldown period (default
+7 minutes). While active the probability of presence remains at `1.0` and
+additional triggers in that room are ignored so the window does not extend.
+Once the cooldown elapses the state resets and the probability drops back to
+a small floor value until another event occurs.
 
 ### Particle Updates
 


### PR DESCRIPTION
## Summary
- add a motion_state flag per room in `SensorModel`
- ignore repeated triggers during the cooldown window
- keep probability at 1.0 until the cooldown expires
- update tests for the new semantics
- document new behaviour in `ADVANCED_TRACKER_README.md`

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q homeassistant`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a3cf4ddac832d9d19382042b3b6b4