### PR TITLE
Respect debug interval when plotting YAML scenarios

### DIFF
--- a/modules/advanced_tracker.py
+++ b/modules/advanced_tracker.py
@@ -274,8 +274,9 @@ class MultiPersonTracker:
         self._updated_since_plot = True
         self._maybe_visualize(now)
 
-    def step(self) -> None:
-        now = time.time()
+    def step(self, timestamp: Optional[float] = None) -> None:
+        """Advance all trackers and maybe render a debug frame."""
+        now = time.time() if timestamp is None else timestamp
         for person in self.people.values():
             person.tracker.update(now)
         self._updated_since_plot = True

--- a/tests/test_advanced_tracker.py
+++ b/tests/test_advanced_tracker.py
@@ -166,13 +166,13 @@ class TestAdvancedTracker(unittest.TestCase):
             frames = [f for f in os.listdir(tmp) if f.startswith('frame_')]
             self.assertEqual(len(frames), 2)
 
-    def _run_yaml_scenario(self, path: str):
+    def _run_yaml_scenario(self, path: str, *, debug: bool = False):
         with open(path, 'r') as f:
             scenario = yaml.safe_load(f)
 
         graph = load_room_graph_from_yaml(scenario['connections'])
         sensor_model = SensorModel()
-        multi = MultiPersonTracker(graph, sensor_model, debug=False)
+        multi = MultiPersonTracker(graph, sensor_model, debug=debug)
 
         # Build mapping of time -> list of (pid, room)
         time_events = {}
@@ -200,6 +200,9 @@ class TestAdvancedTracker(unittest.TestCase):
             for pid, tracker in multi.trackers.items():
                 if pid not in updated:
                     tracker.update(current)
+
+            multi._updated_since_plot = True
+            multi._maybe_visualize(current)
 
             current += 1
 


### PR DESCRIPTION
## Summary
- add timestamp option to `MultiPersonTracker.step`
- ensure `_run_yaml_scenario` plots using the 5‑second debug interval

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685a43effcb0832da6b7e8fbb0c29cdc