### PR TITLE
Add minimum debug plot interval

### DIFF
--- a/modules/ADVANCED_TRACKER_README.md
+++ b/modules/ADVANCED_TRACKER_README.md
@@ -120,6 +120,10 @@ preserved under this dated directory.  A new folder
 is created whenever no event has occurred for `event_window` seconds (default
 `600`), making it easy to inspect separate sequences or collect files per
 test case.
+The frequency of saved frames is controlled by `min_plot_time` which defaults
+to five seconds. A new image is only written when at least this much time has
+passed since the last frame and the tracker state has changed. Scenario YAML
+files can override the value by including a `min_plot_time` field.
 
 ## Testing
 

--- a/tests/test_advanced_tracker.py
+++ b/tests/test_advanced_tracker.py
@@ -42,6 +42,7 @@ class TestAdvancedTracker(unittest.TestCase):
                 debug=True,
                 debug_dir=tmp,
                 test_name=self._testMethodName,
+                min_plot_time=0.0,
             )
             multi.process_event('p1', 'bedroom')
             multi.step()
@@ -81,6 +82,7 @@ class TestAdvancedTracker(unittest.TestCase):
                 debug_dir=tmp,
                 event_window=600,
                 test_name=self._testMethodName,
+                min_plot_time=0.0,
             )
             multi.process_event('p1', 'bedroom', timestamp=0.0)
             multi.process_event('p1', 'kitchen', timestamp=1000.0)
@@ -152,7 +154,12 @@ class TestAdvancedTracker(unittest.TestCase):
 
         graph = load_room_graph_from_yaml(scenario['connections'])
         sensor_model = SensorModel()
-        multi = MultiPersonTracker(graph, sensor_model, test_name=scenario_name)
+        multi = MultiPersonTracker(
+            graph,
+            sensor_model,
+            test_name=scenario_name,
+            min_plot_time=scenario.get('min_plot_time', 5.0),
+        )
 
         # Build mapping of time -> list of (pid, room)
         time_events = {}


### PR DESCRIPTION
## Summary
- throttle debug visualisation frequency
- support `min_plot_time` in YAML scenarios
- update docs for new option
- adjust advanced tracker tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a4b5a1648832d99fc02d7226c91dd