### PR TITLE
Update scenario timings across tests

### DIFF
--- a/tests/scenarios/backtrack_walk.yml
+++ b/tests/scenarios/backtrack_walk.yml
@@ -5,15 +5,15 @@ persons:
     events:
       - time: 0
         room: bedroom
-      - time: 300
+      - time: 240
         room: hallway
-      - time: 600
+      - time: 480
         room: kitchen
-      - time: 900
+      - time: 840
         room: dining_room
-      - time: 1200
+      - time: 1080
         room: hallway
-      - time: 1500
+      - time: 1440
         room: bedroom
 expected_final:
   wanderer: bedroom

--- a/tests/scenarios/missed_event_multi.yml
+++ b/tests/scenarios/missed_event_multi.yml
@@ -5,17 +5,17 @@ persons:
     events:
       - time: 0
         room: bedroom
-      - time: 600
+      - time: 390
         room: kitchen
-      - time: 1200
+      - time: 780
         room: hallway
   - id: bob
     events:
       - time: 0
         room: kitchen
-      - time: 600
+      - time: 330
         room: bedroom
-      - time: 1200
+      - time: 780
         room: hallway
 extra_steps: 20
 expected_final:

--- a/tests/scenarios/missed_event_single.yml
+++ b/tests/scenarios/missed_event_single.yml
@@ -5,9 +5,9 @@ persons:
     events:
       - time: 0
         room: bedroom
-      - time: 600
+      - time: 420
         room: kitchen
-      - time: 1200
+      - time: 870
         room: hallway
 extra_steps: 20
 expected_final:

--- a/tests/scenarios/simple_walk.yml
+++ b/tests/scenarios/simple_walk.yml
@@ -5,13 +5,13 @@ persons:
     events:
       - time: 0
         room: bedroom
-      - time: 600
+      - time: 300
         room: hallway
-      - time: 1200
+      - time: 540
         room: kitchen
-      - time: 1800
+      - time: 960
         room: hallway
-      - time: 2400
+      - time: 1260
         room: bedroom
 extra_steps: 20
 expected_final:

--- a/tests/scenarios/two_people_apart.yml
+++ b/tests/scenarios/two_people_apart.yml
@@ -5,33 +5,33 @@ persons:
     events:
       - time: 0
         room: bedroom
-      - time: 300
+      - time: 240
         room: bathroom
-      - time: 600
+      - time: 540
         room: hallway
-      - time: 900
+      - time: 840
         room: office
-      - time: 1200
+      - time: 1080
         room: laundry_room
-      - time: 1500
+      - time: 1440
         room: laundry_room
-      - time: 1800
+      - time: 1680
         room: laundry_room
   - id: bob
     events:
       - time: 0
         room: kitchen
-      - time: 300
+      - time: 210
         room: dining_room_hallway
-      - time: 600
+      - time: 450
         room: dining_room_1
-      - time: 900
+      - time: 720
         room: dining_room_3
-      - time: 1200
+      - time: 1050
         room: living_room_back
-      - time: 1500
+      - time: 1320
         room: living_room_middle
-      - time: 1800
+      - time: 1590
         room: living_room_front
 extra_steps: 20
 expected_final:

--- a/tests/scenarios/two_people_crossing.yml
+++ b/tests/scenarios/two_people_crossing.yml
@@ -5,21 +5,21 @@ persons:
     events:
       - time: 0
         room: bedroom
-      - time: 300
+      - time: 180
         room: living_room_hallway
-      - time: 600
+      - time: 420
         room: dining_room_hallway
-      - time: 900
+      - time: 660
         room: kitchen
   - id: p2
     events:
       - time: 0
         room: kitchen
-      - time: 300
+      - time: 210
         room: dining_room_hallway
-      - time: 600
+      - time: 450
         room: living_room_hallway
-      - time: 900
+      - time: 690
         room: bedroom
 expected_final:
   p1: kitchen

--- a/tests/scenarios/two_persons.yml
+++ b/tests/scenarios/two_persons.yml
@@ -5,17 +5,17 @@ persons:
     events:
       - time: 0
         room: bedroom
-      - time: 300
+      - time: 210
         room: hallway
-      - time: 600
+      - time: 540
         room: bathroom
   - id: bob
     events:
       - time: 0
         room: kitchen
-      - time: 300
+      - time: 240
         room: hallway
-      - time: 600
+      - time: 540
         room: office
 extra_steps: 20
 expected_final:

--- a/tests/scenarios/walk_across_house.yml
+++ b/tests/scenarios/walk_across_house.yml
@@ -5,45 +5,41 @@ persons:
     events:
       - time: 0
         room: bedroom
-      - time: 300
+      - time: 180
         room: living_room_hallway
-      - time: 600
+      - time: 420
         room: living_room_door
-      - time: 900
+      - time: 600
         room: living_room_front
-      - time: 1200
+      - time: 720
         room: living_room_middle
-      - time: 1500
+      - time: 1020
         room: living_room_back
-      - time: 1800
+      - time: 1260
         room: dining_room_3
-      - time: 2100
+      - time: 1380
         room: dining_room_1
-      - time: 2400
+      - time: 1680
         room: dining_room_hallway
-      - time: 2700
+      - time: 2100
         room: kitchen
-      - time: 3000
+      - time: 2280
         room: hallway
-      - time: 3300
+      - time: 2520
         room: office
-      - time: 3350
+      - time: 2640
         room: laundry_room
-      - time: 3351
+      - time: 2760
         room: laundry_room
-      - time: 3352
+      - time: 2880
         room: laundry_room
-      - time: 3353
+      - time: 3000
         room: laundry_room
-      - time: 3354
+      - time: 3120
         room: laundry_room
-      - time: 3355
+      - time: 3240
         room: laundry_room
-      - time: 3356
-        room: laundry_room
-      - time: 3357
-        room: laundry_room
-      - time: 3358
+      - time: 3360
         room: laundry_room
 extra_steps: 100
 expected_final:


### PR DESCRIPTION
## Summary
- adjust timings across all scenario files for more realistic 2-10 minute waits

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a4b854d24832d9af6935caf006009