### PR TITLE
Reduce number of debug frames

### DIFF
--- a/modules/ADVANCED_TRACKER_README.md
+++ b/modules/ADVANCED_TRACKER_README.md
@@ -121,7 +121,7 @@ is created whenever no event has occurred for `event_window` seconds (default
 `600`), making it easy to inspect separate sequences or collect files per
 test case.
 The frequency of saved frames is controlled by `min_plot_time` which defaults
-to five seconds. A new image is only written when at least this much time has
+to 30 seconds. A new image is only written when at least this much time has
 passed since the last frame and the tracker state has changed. Scenario YAML
 files can override the value by including a `min_plot_time` field.
 

--- a/modules/advanced_tracker.py
+++ b/modules/advanced_tracker.py
@@ -19,6 +19,10 @@ import yaml
 import matplotlib
 
 matplotlib.use("Agg")
+
+# Default delay between saved debug frames. A larger value keeps the number
+# of generated images manageable during long test scenarios.
+DEFAULT_MIN_PLOT_TIME = 30.0
 import matplotlib.pyplot as plt
 import matplotlib.patheffects as patheffects
 
@@ -218,7 +222,7 @@ class MultiPersonTracker:
         debug_dir: str = "debug",
         event_window: int = 600,
         test_name: Optional[str] = None,
-        min_plot_time: float = 5.0,
+        min_plot_time: float = DEFAULT_MIN_PLOT_TIME,
     ):
         self.room_graph = room_graph
         self.sensor_model = sensor_model

--- a/tests/test_advanced_tracker.py
+++ b/tests/test_advanced_tracker.py
@@ -12,6 +12,7 @@ from modules.advanced_tracker import (
     SensorModel,
     PersonTracker,
     MultiPersonTracker,
+    DEFAULT_MIN_PLOT_TIME,
     Phone,
     Person,
 )
@@ -158,7 +159,7 @@ class TestAdvancedTracker(unittest.TestCase):
             graph,
             sensor_model,
             test_name=scenario_name,
-            min_plot_time=scenario.get('min_plot_time', 5.0),
+            min_plot_time=scenario.get('min_plot_time', DEFAULT_MIN_PLOT_TIME),
         )
 
         # Build mapping of time -> list of (pid, room)


### PR DESCRIPTION
## Summary
- introduce `DEFAULT_MIN_PLOT_TIME` (30s) for `MultiPersonTracker`
- reference the new constant in YAML scenario tests
- document the new default in the tracker README

## Testing
- `pip install -r requirements.txt`
- `python3.11 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ac6b65018832d9f6ad35650391e02