### PR TITLE
Use consistent tab10 colors

### DIFF
--- a/modules/advanced_tracker.py
+++ b/modules/advanced_tracker.py
@@ -130,6 +130,12 @@ class PersonTracker:
             for p in self.particles:
                 p.room = sensor_room
             move_particles = False
+        else:
+            if (
+                self.last_sensor_room is not None
+                and current_time - self.last_sensor_time < self.sensor_model.cooldown
+            ):
+                move_particles = False
 
         for p in self.particles:
             if move_particles:
@@ -362,19 +368,15 @@ class MultiPersonTracker:
             edgecolors="black",
         )
 
-        colors = {
-            0: (1, 0, 0),
-            1: (0, 1, 0),
-            2: (0, 0, 1),
-        }
+        cmap = matplotlib.cm.get_cmap("tab10")
         legend_handles = []
         for idx, (pid, person) in enumerate(self.people.items()):
             dist = person.tracker.distribution()
             node_colors = []
             for node in self.room_graph.graph.nodes:
                 intensity = dist.get(node, 0.0)
-                base = colors.get(idx % 3, (0, 0, 0))
-                node_colors.append(tuple(intensity * c for c in base))
+                base_color = cmap(idx % cmap.N)[:3]
+                node_colors.append(tuple(intensity * c for c in base_color))
             nx.draw_networkx_nodes(
                 self.room_graph.graph,
                 pos=self._layout,
@@ -395,7 +397,7 @@ class MultiPersonTracker:
                 ax.plot(
                     [p[0] for p in est_points],
                     [p[1] for p in est_points],
-                    color=colors.get(idx % 3, (0, 0, 0)),
+                    color=cmap(idx % cmap.N),
                 )
 
             ev_points = []
@@ -416,7 +418,7 @@ class MultiPersonTracker:
                 mlines.Line2D(
                     [],
                     [],
-                    color=colors.get(idx % 3, (0, 0, 0)),
+                    color=cmap(idx % cmap.N),
                     label=f"{pid}: {int(max_prob * 100 + 0.5)}%",
                 )
             )


### PR DESCRIPTION
## Summary
- colorize advanced tracker with matplotlib's `tab10` palette
- keep particles fixed until motion cooldown expires

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b9a923eb4832d929c471fe2d7d109