### PR TITLE
Add true location lines to tracker timeline

### DIFF
--- a/modules/advanced_tracker.py
+++ b/modules/advanced_tracker.py
@@ -660,6 +660,30 @@ class MultiPersonTracker:
                 color=colors,
                 zorder=3,
             )
+            # Draw horizontal line segments showing the true location of each
+            # person based on the scenario (tests only).
+            if self.test_name:
+                for idx, pid in enumerate(self.people.keys()):
+                    pid_events = [
+                        (t, r)
+                        for t, r, p in self._sensor_events
+                        if p == pid
+                    ]
+                    pid_events.sort()
+                    for j, (t, room) in enumerate(pid_events):
+                        start = t
+                        end = (
+                            pid_events[j + 1][0]
+                            if j + 1 < len(pid_events)
+                            else current_time
+                        )
+                        timeline_ax.plot(
+                            [start - self._start_time, end - self._start_time],
+                            [indices[room], indices[room]],
+                            color=PERSON_COLORS[idx % len(PERSON_COLORS)],
+                            lw=2,
+                            zorder=2,
+                        )
             timeline_ax.set_yticks(list(indices.values()))
             timeline_ax.set_yticklabels(rooms)
             timeline_ax.set_xlabel("Time (s)")
@@ -695,6 +719,7 @@ class MultiPersonTracker:
             color_hex = mcolors.to_hex(PERSON_COLORS[idx % len(PERSON_COLORS)])
             legend_lines.append(f"  {pid}: {color_hex}")
         legend_lines.append("  timeline dot color = person id")
+        legend_lines.append("  timeline line: true location (tests only)")
         legend_lines.append("  solid line: estimated path")
         legend_lines.append("  dashed orange: true path (tests only)")
 

--- a/tests/test_advanced_tracker.py
+++ b/tests/test_advanced_tracker.py
@@ -62,6 +62,7 @@ class TestAdvancedTracker(unittest.TestCase):
             self.assertTrue(any(line.strip().startswith('p1:') for line in legend))
             self.assertTrue(any('solid line: estimated path' in line for line in legend))
             self.assertTrue(any('dashed orange: true path (tests only)' in line for line in legend))
+            self.assertTrue(any('timeline line: true location (tests only)' in line for line in legend))
 
     def test_event_log_includes_timestamp(self):
         graph = load_room_graph_from_yaml('connections.yml')


### PR DESCRIPTION
## Summary
- show the ground-truth location on the sensor activation timeline
- document the new legend entry and test for it

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a72c4d258832d9cc9ed7621c7bcfd